### PR TITLE
Added colored rendering to Button and TextElement.

### DIFF
--- a/src/engine/UI/Button.cpp
+++ b/src/engine/UI/Button.cpp
@@ -5,13 +5,19 @@
 
 using namespace admirals::UI;
 
-Button::Button(const std::string &name, const std::string &text, vec2 size)
-    : Element(name, text, size) {}
+Button::Button(const std::string &name, const std::string &text,
+               const vec2 size, const vec4 backgroundColor,
+               const vec4 foregroundColor)
+    : Element(name, text, size) {
+    for (int i = 0; i < 4; i++) {
+        m_bgColor[i] = backgroundColor[i];
+        m_fgColor[i] = foregroundColor[i];
+    }
+}
 
 void Button::Render(const VK2DTexture font, const vec2 startPos) {
-    // TODO: Use Element colors here (m_bgColor, m_fgColor).
-    renderer::Renderer::drawRectangle(startPos, m_displaySize, VK2D_BLACK);
-    renderer::Renderer::drawText(font, startPos, VK2D_WHITE, m_text.c_str());
+    renderer::Renderer::drawRectangle(startPos, m_displaySize, m_bgColor);
+    renderer::Renderer::drawText(font, startPos, m_fgColor, m_text.c_str());
 }
 
 bool Button::HandleEvent(const SDL_Event &event) { return false; }

--- a/src/engine/UI/Button.hpp
+++ b/src/engine/UI/Button.hpp
@@ -10,11 +10,15 @@ namespace UI {
 
 class Button : public Element {
 public:
-    Button(const std::string &name, const std::string &text, vec2 size);
+    Button(const std::string &name, const std::string &text, const vec2 size,
+           const vec4 backgroundColor, const vec4 foregroundColor);
 
     virtual void Render(const VK2DTexture font, const vec2 startPos);
 
     virtual bool HandleEvent(const SDL_Event &event) override;
+
+private:
+    vec4 m_bgColor, m_fgColor;
 };
 
 } // namespace UI

--- a/src/engine/UI/Element.cpp
+++ b/src/engine/UI/Element.cpp
@@ -4,11 +4,10 @@
 
 using namespace admirals::UI;
 
-Element::Element(const std::string &name, const std::string &text, vec2 size) {
+Element::Element(const std::string &name, const std::string &text,
+                 const vec2 size) {
     this->m_name = name;
     this->m_text = text;
     this->m_displaySize[0] = size[0];
     this->m_displaySize[1] = size[1];
-    vk2dColourHex(this->m_fgColor, "FFFFFF");
-    vk2dColourHex(this->m_bgColor, "000000");
 }

--- a/src/engine/UI/Element.hpp
+++ b/src/engine/UI/Element.hpp
@@ -20,7 +20,7 @@ enum DisplayPosition {
 // General UI element that can be rendered.
 class Element {
 public:
-    Element(const std::string &name, const std::string &text, vec2 size);
+    Element(const std::string &name, const std::string &text, const vec2 size);
     virtual ~Element(){};
 
     // Getters and setters
@@ -55,9 +55,6 @@ protected:
 
     // Text to be displayed on the Element.
     std::string m_text;
-
-    // Colors for rendering.
-    vec4 m_fgColor, m_bgColor;
 
     // Size for displaying/rendering the element to the screen.
     vec2 m_displaySize;

--- a/src/engine/UI/TextElement.cpp
+++ b/src/engine/UI/TextElement.cpp
@@ -6,15 +6,18 @@
 using namespace admirals::UI;
 
 TextElement::TextElement(const std::string &name, const std::string &text,
-                         vec2 size)
-    : Element(name, text, size) {}
+                         const vec2 size, const vec4 color)
+    : Element(name, text, size) {
+
+    for (int i = 0; i < 4; i++) {
+        m_textColor[i] = color[i];
+    }
+}
 
 void TextElement::SetText(const std::string &text) { this->m_text = text; }
 
 void TextElement::Render(const VK2DTexture font, const vec2 startPos) {
-    // TODO: Use Element colors here (m_fgColor).
-    // Draw foreground (text).
-    renderer::Renderer::drawText(font, startPos, VK2D_BLACK,
+    renderer::Renderer::drawText(font, startPos, m_textColor,
                                  this->m_text.c_str());
 }
 

--- a/src/engine/UI/TextElement.hpp
+++ b/src/engine/UI/TextElement.hpp
@@ -10,13 +10,17 @@ namespace UI {
 
 class TextElement : public Element {
 public:
-    TextElement(const std::string &name, const std::string &text, vec2 size);
+    TextElement(const std::string &name, const std::string &text,
+                const vec2 size, const vec4 color);
 
     void SetText(const std::string &text);
 
     virtual void Render(const VK2DTexture font, const vec2 startPos);
 
     virtual bool HandleEvent(const SDL_Event &event) override;
+
+private:
+    vec4 m_textColor;
 };
 
 } // namespace UI

--- a/src/test/gameObject.test.cpp
+++ b/src/test/gameObject.test.cpp
@@ -97,7 +97,7 @@ int main(int argc, char *argv[]) {
         new UI::DisplayLayout(WINDOW_WIDTH, WINDOW_HEIGHT);
     vec2 elementSize = {150, 40};
 
-    UI::TextElement fpsText("Fps TextElement", "", elementSize);
+    UI::TextElement fpsText("Fps TextElement", "", elementSize, VK2D_BLACK);
     fpsText.SetDisplayPosition(UI::DisplayPosition::LowerLeft);
     auto sharedFpsText = UI::Element::createFromDerived(fpsText);
 

--- a/src/test/renderer.test.cpp
+++ b/src/test/renderer.test.cpp
@@ -60,11 +60,14 @@ int main(int argc, char *argv[]) {
 
     vec2 elementSize = {150, 40};
 
-    admirals::UI::Button testBtn("Test Button1", "Click Me!", elementSize);
+    vec4 grey;
+    vk2dColourRGBA(grey, 54, 54, 54, 255);
+    admirals::UI::Button testBtn("Test Button1", "Click Me!", elementSize,
+                                 VK2D_WHITE, grey);
     layout.AddElement(std::make_unique<admirals::UI::Button>(testBtn));
 
-    admirals::UI::TextElement testText("Text Element1",
-                                       "This is a text element.", elementSize);
+    admirals::UI::TextElement testText(
+        "Text Element1", "This is a text element.", elementSize, VK2D_WHITE);
     testText.SetDisplayPosition(admirals::UI::DisplayPosition::LowerLeft);
     layout.AddElement(std::make_unique<admirals::UI::TextElement>(testText));
 


### PR DESCRIPTION
This is a refactor of the additions introduced in #13. The Element class no longer keeps track of colors, which have instead been moved to its subclasses (Button and TextElement). Button keeps track of both a foreground and background color whilst TextElement only keeps track of a text color. 

Additionally, all `vecN` parameters have been made constant to indicate that they are not changing any values.

Closes #16 