### PR TITLE
Implemented re-sizable windows

### DIFF
--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -11,9 +11,7 @@ Engine::Engine(const std::string &gameName, int windowWidth, int windowHeight,
     // DisplayLayout requires vk2d to be initialized.
     m_renderer->init(debug);
 
-    m_displayLayout =
-        std::make_shared<UI::DisplayLayout>(windowWidth, windowHeight);
-
+    m_displayLayout = std::make_shared<UI::DisplayLayout>();
     m_scene = std::make_shared<scene::Scene>();
 }
 

--- a/src/engine/GameObject.hpp
+++ b/src/engine/GameObject.hpp
@@ -2,7 +2,7 @@
 #include <memory>
 
 #include "DataObjects.hpp"
-#include "Renderer.hpp"
+#include "IDrawable.hpp"
 
 namespace admirals {
 namespace scene {
@@ -18,7 +18,7 @@ public:
     virtual void onUpdate() = 0;
     virtual void onStart() = 0;
     // Should not be part of GameObject...
-    virtual void render(const renderer::Renderer *r) = 0; 
+    virtual void render(const renderer::RendererContext &r) = 0; 
 
     template <typename T>
     static std::shared_ptr<GameObject>

--- a/src/engine/GameObject.hpp
+++ b/src/engine/GameObject.hpp
@@ -18,7 +18,7 @@ public:
     virtual void onUpdate() = 0;
     virtual void onStart() = 0;
     // Should not be part of GameObject...
-    virtual void render(const renderer::RendererContext &r) = 0; 
+    virtual void render(const renderer::RendererContext &r) = 0;
 
     template <typename T>
     static std::shared_ptr<GameObject>

--- a/src/engine/GameObject.hpp
+++ b/src/engine/GameObject.hpp
@@ -1,7 +1,8 @@
 #pragma once
+#include <memory>
 
 #include "DataObjects.hpp"
-#include <memory>
+#include "Renderer.hpp"
 
 namespace admirals {
 namespace scene {
@@ -16,7 +17,8 @@ public:
 
     virtual void onUpdate() = 0;
     virtual void onStart() = 0;
-    virtual void render() = 0; // Should not be part of GameObject...
+    // Should not be part of GameObject...
+    virtual void render(const renderer::Renderer *r) = 0; 
 
     template <typename T>
     static std::shared_ptr<GameObject>

--- a/src/engine/IDrawable.hpp
+++ b/src/engine/IDrawable.hpp
@@ -2,13 +2,14 @@
 
 namespace admirals {
 namespace renderer {
+class Renderer;
 
 class IDrawable {
 public:
     IDrawable(){};
     ~IDrawable(){};
 
-    virtual void render() const = 0;
+    virtual void render(const renderer::Renderer *r) const = 0;
 };
 
 } // namespace renderer

--- a/src/engine/IDrawable.hpp
+++ b/src/engine/IDrawable.hpp
@@ -2,14 +2,18 @@
 
 namespace admirals {
 namespace renderer {
-class Renderer;
+
+struct RendererContext {
+    int windowWidth;
+    int windowHeight;
+};
 
 class IDrawable {
 public:
     IDrawable(){};
     ~IDrawable(){};
 
-    virtual void render(const renderer::Renderer *r) const = 0;
+    virtual void render(const RendererContext &r) const = 0;
 };
 
 } // namespace renderer

--- a/src/engine/InteractiveDrawable.hpp
+++ b/src/engine/InteractiveDrawable.hpp
@@ -10,7 +10,7 @@ public:
     InteractiveDrawable(){};
     ~InteractiveDrawable(){};
 
-    virtual void render() const = 0;
+    virtual void render(const renderer::Renderer *r) const = 0;
     virtual void handleEvent(SDL_Event &e) = 0;
 };
 

--- a/src/engine/InteractiveDrawable.hpp
+++ b/src/engine/InteractiveDrawable.hpp
@@ -10,7 +10,7 @@ public:
     InteractiveDrawable(){};
     ~InteractiveDrawable(){};
 
-    virtual void render(const renderer::Renderer *r) const = 0;
+    virtual void render(const renderer::RendererContext &r) const = 0;
     virtual void handleEvent(SDL_Event &e) = 0;
 };
 

--- a/src/engine/Renderer.cpp
+++ b/src/engine/Renderer.cpp
@@ -48,9 +48,13 @@ int Renderer::init(bool debug) {
         return code;
     }
 
-    VK2DCameraSpec camera = {
-        VK2D_CAMERA_TYPE_DEFAULT, 0, 0, m_context.windowWidth,
-        m_context.windowHeight,   1, 0};
+    VK2DCameraSpec camera = {VK2D_CAMERA_TYPE_DEFAULT,
+                             0,
+                             0,
+                             static_cast<float>(m_context.windowWidth),
+                             static_cast<float>(m_context.windowHeight),
+                             1,
+                             0};
 
     vk2dRendererSetCamera(camera);
     return code;

--- a/src/engine/Renderer.cpp
+++ b/src/engine/Renderer.cpp
@@ -26,9 +26,7 @@ void RenderFont(const VK2DTexture font, const admirals::Vector2 &postion,
     }
 }
 
-Renderer::Renderer(const std::string &name, int width, int height) {
-    this->m_windowWidth = width;
-    this->m_windowHeight = height;
+Renderer::Renderer(const std::string &name, int width, int height) : m_context({ width, height }) {
     this->m_window = SDL_CreateWindow(name.c_str(), SDL_WINDOWPOS_CENTERED,
                                       SDL_WINDOWPOS_CENTERED, width, height,
                                       SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE);
@@ -49,22 +47,17 @@ int Renderer::init(bool debug) {
         return code;
     }
 
-    VK2DCameraSpec camera = {
-        VK2D_CAMERA_TYPE_DEFAULT,    0, 0, (float)this->m_windowWidth,
-        (float)this->m_windowHeight, 1, 0};
+    VK2DCameraSpec camera = { VK2D_CAMERA_TYPE_DEFAULT, 0, 0, m_context.windowWidth, m_context.windowHeight, 1, 0};
 
     vk2dRendererSetCamera(camera);
     return code;
 }
 
-int Renderer::windowWidth() const { return m_windowWidth; }
-int Renderer::windowHeight() const { return m_windowHeight; }
-
 void Renderer::render(const DrawableCollection &drawable) {
     vk2dRendererStartFrame(Color::WHITE.data());
-    SDL_GetWindowSize(m_window, &m_windowWidth, &m_windowHeight);
+    SDL_GetWindowSize(m_window, &m_context.windowWidth, &m_context.windowHeight);
     for (const auto &d : drawable) {
-        d->render(this);
+        d->render(m_context);
     }
     vk2dRendererEndFrame();
 }

--- a/src/engine/Renderer.cpp
+++ b/src/engine/Renderer.cpp
@@ -1,3 +1,5 @@
+#include <VK2D/Constants.h>
+#include <VK2D/Renderer.h>
 #include <cmath>
 
 #include "DataObjects.hpp"
@@ -55,10 +57,14 @@ int Renderer::init(bool debug) {
     return code;
 }
 
+int Renderer::windowWidth() const { return m_windowWidth; }
+int Renderer::windowHeight() const { return m_windowHeight; }
+
 void Renderer::render(const DrawableCollection &drawable) {
-    vk2dRendererStartFrame(VK2D_WHITE);
+    vk2dRendererStartFrame(Color::WHITE.data());
+    SDL_GetWindowSize(m_window, &m_windowWidth, &m_windowHeight);
     for (const auto &d : drawable) {
-        d->render();
+        d->render(this);
     }
     vk2dRendererEndFrame();
 }

--- a/src/engine/Renderer.cpp
+++ b/src/engine/Renderer.cpp
@@ -26,7 +26,8 @@ void RenderFont(const VK2DTexture font, const admirals::Vector2 &postion,
     }
 }
 
-Renderer::Renderer(const std::string &name, int width, int height) : m_context({ width, height }) {
+Renderer::Renderer(const std::string &name, int width, int height)
+    : m_context({width, height}) {
     this->m_window = SDL_CreateWindow(name.c_str(), SDL_WINDOWPOS_CENTERED,
                                       SDL_WINDOWPOS_CENTERED, width, height,
                                       SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE);
@@ -47,7 +48,9 @@ int Renderer::init(bool debug) {
         return code;
     }
 
-    VK2DCameraSpec camera = { VK2D_CAMERA_TYPE_DEFAULT, 0, 0, m_context.windowWidth, m_context.windowHeight, 1, 0};
+    VK2DCameraSpec camera = {
+        VK2D_CAMERA_TYPE_DEFAULT, 0, 0, m_context.windowWidth,
+        m_context.windowHeight,   1, 0};
 
     vk2dRendererSetCamera(camera);
     return code;
@@ -55,7 +58,8 @@ int Renderer::init(bool debug) {
 
 void Renderer::render(const DrawableCollection &drawable) {
     vk2dRendererStartFrame(Color::WHITE.data());
-    SDL_GetWindowSize(m_window, &m_context.windowWidth, &m_context.windowHeight);
+    SDL_GetWindowSize(m_window, &m_context.windowWidth,
+                      &m_context.windowHeight);
     for (const auto &d : drawable) {
         d->render(m_context);
     }

--- a/src/engine/Renderer.hpp
+++ b/src/engine/Renderer.hpp
@@ -4,7 +4,8 @@
 #include <string>
 #include <vector>
 
-#include <VK2D/VK2D.h>
+#include <SDL2/SDL_video.h>
+#include <VK2D/Texture.h>
 
 #include "DataObjects.hpp"
 #include "IDrawable.hpp"
@@ -21,6 +22,8 @@ public:
 
     int init(bool debug);
     void render(const DrawableCollection &drawable);
+    int windowWidth() const;
+    int windowHeight() const;
 
     static void drawRectangle(const Vector2 &position, const Vector2 &size,
                               const Color &color);

--- a/src/engine/Renderer.hpp
+++ b/src/engine/Renderer.hpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-#include <SDL2/SDL_video.h>
+#include <SDL_video.h>
 #include <VK2D/Texture.h>
 
 #include "DataObjects.hpp"
@@ -22,8 +22,7 @@ public:
 
     int init(bool debug);
     void render(const DrawableCollection &drawable);
-    int windowWidth() const;
-    int windowHeight() const;
+    inline RendererContext context() const { return m_context; }
 
     static void drawRectangle(const Vector2 &position, const Vector2 &size,
                               const Color &color);
@@ -32,8 +31,7 @@ public:
                          const Color &color, const std::string &text);
 
 private:
-    int m_windowWidth;
-    int m_windowHeight;
+    RendererContext m_context;
     SDL_Window *m_window;
 };
 

--- a/src/engine/Scene.cpp
+++ b/src/engine/Scene.cpp
@@ -2,10 +2,10 @@
 
 using namespace admirals::scene;
 
-void Scene::render() const {
+void Scene::render(const renderer::Renderer *r) const {
     for (auto &object : this->m_objects) {
         object->onUpdate();
-        object->render();
+        object->render(r);
     }
 }
 

--- a/src/engine/Scene.cpp
+++ b/src/engine/Scene.cpp
@@ -2,7 +2,7 @@
 
 using namespace admirals::scene;
 
-void Scene::render(const renderer::Renderer *r) const {
+void Scene::render(const renderer::RendererContext &r) const {
     for (auto &object : this->m_objects) {
         object->onUpdate();
         object->render(r);

--- a/src/engine/Scene.hpp
+++ b/src/engine/Scene.hpp
@@ -26,7 +26,7 @@ public:
     Scene();
     ~Scene();
 
-    void render(const renderer::Renderer *r) const;
+    void render(const renderer::RendererContext &r) const;
     void addObject(std::shared_ptr<GameObject> object);
 };
 

--- a/src/engine/Scene.hpp
+++ b/src/engine/Scene.hpp
@@ -26,7 +26,7 @@ public:
     Scene();
     ~Scene();
 
-    void render() const;
+    void render(const renderer::Renderer *r) const;
     void addObject(std::shared_ptr<GameObject> object);
 };
 

--- a/src/engine/UI/DisplayLayout.cpp
+++ b/src/engine/UI/DisplayLayout.cpp
@@ -13,7 +13,7 @@ void DisplayLayout::AddElement(std::shared_ptr<Element> element) {
     m_elements.push_back(std::move(element));
 }
 
-float GetHeightFromDisplayPosition(DisplayPosition pos,
+static float GetHeightFromDisplayPosition(DisplayPosition pos,
                                    const Vector2 &displaySize,
                                    const Vector2 &windowSize) {
     float height = 0;
@@ -32,15 +32,14 @@ float GetHeightFromDisplayPosition(DisplayPosition pos,
     return height;
 }
 
-void DisplayLayout::render(const renderer::Renderer *r) const {
+void DisplayLayout::render(const renderer::RendererContext &r) const {
     Vector4 positionOffsets = Vector4(0);
 
     for (const auto &element : m_elements) {
         DisplayPosition pos = element->GetDisplayPosition();
         Vector2 displaySize = element->GetDisplaySize();
 
-        float startHeight = GetHeightFromDisplayPosition(
-            pos, displaySize, Vector2(r->windowWidth(), r->windowHeight()));
+        float startHeight = GetHeightFromDisplayPosition(pos, displaySize, Vector2(r.windowWidth, r.windowHeight));
         element->SetDisplayOrigin(Vector2(positionOffsets[pos], startHeight));
         element->Render(this->m_font);
 

--- a/src/engine/UI/DisplayLayout.cpp
+++ b/src/engine/UI/DisplayLayout.cpp
@@ -1,10 +1,10 @@
 #include "DisplayLayout.hpp"
+#include "Renderer.hpp"
 
+using namespace admirals;
 using namespace admirals::UI;
 
-DisplayLayout::DisplayLayout(int windowWidth, int windowHeight)
-    : m_windowWidth(windowWidth), m_windowHeight(windowHeight) {
-
+DisplayLayout::DisplayLayout() {
     // TODO: This path should probably be configured someplace else.
     m_font = vk2dTextureLoad("assets/font.png");
 }
@@ -13,8 +13,9 @@ void DisplayLayout::AddElement(std::shared_ptr<Element> element) {
     m_elements.push_back(std::move(element));
 }
 
-float DisplayLayout::GetHeightFromDisplayPosition(
-    DisplayPosition pos, const Vector2 &displaySize) const {
+float GetHeightFromDisplayPosition(DisplayPosition pos,
+                                   const Vector2 &displaySize,
+                                   const Vector2 &windowSize) {
     float height = 0;
 
     switch (pos) {
@@ -24,22 +25,22 @@ float DisplayLayout::GetHeightFromDisplayPosition(
         break;
     case DisplayPosition::LowerLeft:
     case DisplayPosition::LowerRight:
-        height = (float)m_windowHeight - displaySize[1];
+        height = windowSize[1] - displaySize[1];
         break;
     }
 
     return height;
 }
 
-void DisplayLayout::render() const {
-
-    float positionOffsets[4] = {0};
+void DisplayLayout::render(const renderer::Renderer *r) const {
+    Vector4 positionOffsets = Vector4(0);
 
     for (const auto &element : m_elements) {
         DisplayPosition pos = element->GetDisplayPosition();
         Vector2 displaySize = element->GetDisplaySize();
 
-        float startHeight = GetHeightFromDisplayPosition(pos, displaySize);
+        float startHeight = GetHeightFromDisplayPosition(
+            pos, displaySize, Vector2(r->windowWidth(), r->windowHeight()));
         element->SetDisplayOrigin(Vector2(positionOffsets[pos], startHeight));
         element->Render(this->m_font);
 

--- a/src/engine/UI/DisplayLayout.cpp
+++ b/src/engine/UI/DisplayLayout.cpp
@@ -14,8 +14,8 @@ void DisplayLayout::AddElement(std::shared_ptr<Element> element) {
 }
 
 static float GetHeightFromDisplayPosition(DisplayPosition pos,
-                                   const Vector2 &displaySize,
-                                   const Vector2 &windowSize) {
+                                          const Vector2 &displaySize,
+                                          const Vector2 &windowSize) {
     float height = 0;
 
     switch (pos) {
@@ -39,7 +39,8 @@ void DisplayLayout::render(const renderer::RendererContext &r) const {
         DisplayPosition pos = element->GetDisplayPosition();
         Vector2 displaySize = element->GetDisplaySize();
 
-        float startHeight = GetHeightFromDisplayPosition(pos, displaySize, Vector2(r.windowWidth, r.windowHeight));
+        float startHeight = GetHeightFromDisplayPosition(
+            pos, displaySize, Vector2(r.windowWidth, r.windowHeight));
         element->SetDisplayOrigin(Vector2(positionOffsets[pos], startHeight));
         element->Render(this->m_font);
 

--- a/src/engine/UI/DisplayLayout.hpp
+++ b/src/engine/UI/DisplayLayout.hpp
@@ -4,7 +4,7 @@
 #include <memory>
 #include <vector>
 
-#include <VK2D/VK2D.h>
+#include <VK2D/Texture.h>
 
 #include "Element.hpp"
 #include "InteractiveDrawable.hpp"
@@ -14,20 +14,14 @@ namespace UI {
 
 class DisplayLayout : public InteractiveDrawable {
 public:
-    DisplayLayout(int windowWidth, int windowHeight);
+    DisplayLayout();
 
     void AddElement(std::shared_ptr<Element> element);
-
-    float GetHeightFromDisplayPosition(DisplayPosition pos,
-                                       const Vector2 &displaySize) const;
-
-    void render() const;
+    void render(const renderer::Renderer *r) const;
     void handleEvent(SDL_Event &e);
 
 private:
     VK2DTexture m_font;
-
-    int m_windowWidth, m_windowHeight;
     std::vector<std::shared_ptr<Element>> m_elements;
 };
 

--- a/src/engine/UI/DisplayLayout.hpp
+++ b/src/engine/UI/DisplayLayout.hpp
@@ -17,7 +17,7 @@ public:
     DisplayLayout();
 
     void AddElement(std::shared_ptr<Element> element);
-    void render(const renderer::Renderer *r) const;
+    void render(const renderer::RendererContext &r) const;
     void handleEvent(SDL_Event &e);
 
 private:

--- a/src/test/gameObject.test.cpp
+++ b/src/test/gameObject.test.cpp
@@ -39,11 +39,11 @@ public:
         this->setPosition(position);
     }
 
-    void render(const renderer::Renderer *r) {
+    void render(const renderer::RendererContext &r) {
         Vector2 pos = this->position();
         // Calculate scaling
-        float x = r->windowWidth() / ((float)WINDOW_WIDTH);
-        float y = r->windowHeight() / ((float)WINDOW_HEIGHT);
+        float x = r.windowWidth / ((float)WINDOW_WIDTH);
+        float y = r.windowHeight / ((float)WINDOW_HEIGHT);
         
         Vector2 size(100.f * x, 100.f * y);
         pos[0] *= x;

--- a/src/test/gameObject.test.cpp
+++ b/src/test/gameObject.test.cpp
@@ -21,6 +21,7 @@ using namespace admirals;
 class CellObject : public scene::GameObject {
 private:
     Color m_color;
+    int m_windowWidth, m_windowHeight;
 
 public:
     CellObject(const Vector3 &pos, const Color &color)
@@ -38,10 +39,16 @@ public:
         this->setPosition(position);
     }
 
-    void render() {
-        Vector2 size(100, 100);
-        renderer::Renderer::drawRectangle(this->position(), size,
-                                          this->m_color);
+    void render(const renderer::Renderer *r) {
+        Vector2 pos = this->position();
+        // Calculate scaling
+        float x = r->windowWidth() / ((float)WINDOW_WIDTH);
+        float y = r->windowHeight() / ((float)WINDOW_HEIGHT);
+        
+        Vector2 size(100.f * x, 100.f * y);
+        pos[0] *= x;
+        pos[1] *= y;
+        renderer::Renderer::drawRectangle(pos, size, this->m_color);
     }
 };
 
@@ -83,8 +90,7 @@ int main(int argc, char *argv[]) {
     CellObject cell6 = CellObject(Vector3(200, 200, 0), Color::GREEN);
     scene->addObject(scene::GameObject::createFromDerived(cell6));
 
-    UI::DisplayLayout *layout =
-        new UI::DisplayLayout(WINDOW_WIDTH, WINDOW_HEIGHT);
+    UI::DisplayLayout *layout = new UI::DisplayLayout();
     UI::TextElement fpsText("Fps TextElement", "", Vector2(150, 40),
                             Color::BLACK);
     fpsText.SetDisplayPosition(UI::DisplayPosition::LowerLeft);

--- a/src/test/gameObject.test.cpp
+++ b/src/test/gameObject.test.cpp
@@ -42,8 +42,8 @@ public:
     void render(const renderer::RendererContext &r) {
         Vector2 pos = this->position();
         // Calculate scaling
-        float x = r.windowWidth / ((float)WINDOW_WIDTH);
-        float y = r.windowHeight / ((float)WINDOW_HEIGHT);
+        float x = r.windowWidth / static_cast<float>(WINDOW_WIDTH);
+        float y = r.windowHeight / static_cast<float>(WINDOW_HEIGHT);
 
         Vector2 size(100.f * x, 100.f * y);
         pos[0] *= x;

--- a/src/test/gameObject.test.cpp
+++ b/src/test/gameObject.test.cpp
@@ -44,7 +44,7 @@ public:
         // Calculate scaling
         float x = r.windowWidth / ((float)WINDOW_WIDTH);
         float y = r.windowHeight / ((float)WINDOW_HEIGHT);
-        
+
         Vector2 size(100.f * x, 100.f * y);
         pos[0] *= x;
         pos[1] *= y;

--- a/src/test/renderer.test.cpp
+++ b/src/test/renderer.test.cpp
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <time.h>
+#include <cmath>
 
 #include <SDL_vulkan.h>
 #include <VK2D/VK2D.h>
@@ -22,8 +23,8 @@ using namespace admirals;
 class TextureObject : public scene::GameObject {
 public:
     TextureObject(const Vector3 &pos, const char *texturePath, float width,
-                  float height)
-        : scene::GameObject(pos), m_width(width), m_height(height) {
+                  float height, bool keepAspectRatio = true)
+        : scene::GameObject(pos), m_width(width), m_height(height), m_keepAspectRatio(keepAspectRatio) {
         m_texture = vk2dTextureLoad(texturePath);
     }
 
@@ -33,9 +34,14 @@ public:
 
     void onUpdate() {}
 
-    void render(const renderer::Renderer *r) {
-        float x = r->windowWidth() / m_width;
-        float y = r->windowHeight() / m_height;
+    void render(const renderer::RendererContext &r) {
+        float x = r.windowWidth / m_width;
+        float y = r.windowHeight / m_height;
+        if (m_keepAspectRatio) {
+            x = std::min(x, y);
+            y = x;
+        }
+
         vk2dRendererDrawTexture(m_texture, 0, 0, x, y, 0, 0, 0, 0, 0, m_width,
                                 m_height);
     }
@@ -43,6 +49,7 @@ public:
 private:
     VK2DTexture m_texture;
     float m_width, m_height;
+    bool m_keepAspectRatio;
 };
 
 void OnButtonClick(UI::Button *button, const SDL_Event &event) {

--- a/src/test/renderer.test.cpp
+++ b/src/test/renderer.test.cpp
@@ -1,8 +1,8 @@
+#include <cmath>
 #include <memory>
 #include <stdbool.h>
 #include <stdio.h>
 #include <time.h>
-#include <cmath>
 
 #include <SDL_vulkan.h>
 #include <VK2D/VK2D.h>
@@ -24,7 +24,8 @@ class TextureObject : public scene::GameObject {
 public:
     TextureObject(const Vector3 &pos, const char *texturePath, float width,
                   float height, bool keepAspectRatio = true)
-        : scene::GameObject(pos), m_width(width), m_height(height), m_keepAspectRatio(keepAspectRatio) {
+        : scene::GameObject(pos), m_width(width), m_height(height),
+          m_keepAspectRatio(keepAspectRatio) {
         m_texture = vk2dTextureLoad(texturePath);
     }
 

--- a/src/test/renderer.test.cpp
+++ b/src/test/renderer.test.cpp
@@ -33,9 +33,11 @@ public:
 
     void onUpdate() {}
 
-    void render() {
-        vk2dRendererDrawTexture(m_texture, 0, 0, 0.4, 0.4, 0, 0, 0, 0, 0,
-                                m_width, m_height);
+    void render(const renderer::Renderer *r) {
+        float x = r->windowWidth() / m_width;
+        float y = r->windowHeight() / m_height;
+        vk2dRendererDrawTexture(m_texture, 0, 0, x, y, 0, 0, 0, 0, 0, m_width,
+                                m_height);
     }
 
 private:


### PR DESCRIPTION
Fixes #27 
Renderer now provides access to the current window width & height.
Renderer is sent as an argument to render functions.

![image](https://github.com/joelsiks/admirals/assets/57936645/69ef805f-abd6-481a-ae2b-e288b510aa78)
![image](https://github.com/joelsiks/admirals/assets/57936645/8c4bb991-bd24-40a2-aa59-6e4deca3dabd)

If preserving aspect ratio:
![image](https://github.com/joelsiks/admirals/assets/57936645/f974afb6-e08c-4656-a719-361c30f8334c)
