### PR TITLE
DislayLayout right alignment fix and debug UI rendering

### DIFF
--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -6,7 +6,7 @@ using namespace admirals;
 Engine::Engine(const std::string &gameName, int windowWidth, int windowHeight,
                bool debug) {
     m_renderer = std::make_shared<renderer::Renderer>(gameName, windowWidth,
-                                                      windowHeight);
+                                                      windowHeight, debug);
     // Initialize the renderer right after creating it. Necessary in cases where
     // DisplayLayout requires vk2d to be initialized.
     m_renderer->init(debug);

--- a/src/engine/IDrawable.hpp
+++ b/src/engine/IDrawable.hpp
@@ -6,6 +6,9 @@ namespace renderer {
 struct RendererContext {
     int windowWidth;
     int windowHeight;
+
+    // Indicates whether to draw outlines of elements for debugging purposes.
+    bool renderDebugOutlines;
 };
 
 class IDrawable {

--- a/src/engine/Renderer.cpp
+++ b/src/engine/Renderer.cpp
@@ -26,8 +26,9 @@ void RenderFont(const VK2DTexture font, const admirals::Vector2 &postion,
     }
 }
 
-Renderer::Renderer(const std::string &name, int width, int height)
-    : m_context({width, height}) {
+Renderer::Renderer(const std::string &name, int width, int height,
+                   bool debugRendering)
+    : m_context({width, height, debugRendering}) {
     this->m_window = SDL_CreateWindow(name.c_str(), SDL_WINDOWPOS_CENTERED,
                                       SDL_WINDOWPOS_CENTERED, width, height,
                                       SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE);
@@ -75,6 +76,16 @@ void Renderer::drawRectangle(const Vector2 &position, const Vector2 &size,
     vk2dRendererSetColourMod(color.data());
     vk2dRendererDrawRectangle(position[0], position[1], size[0], size[1], 0, 0,
                               0);
+    vk2dRendererSetColourMod(VK2D_DEFAULT_COLOUR_MOD);
+}
+
+void Renderer::drawRectangleOutline(const Vector2 &position,
+                                    const Vector2 &size,
+                                    const float outlineWidth,
+                                    const Color &color) {
+    vk2dRendererSetColourMod(color.data());
+    vk2dRendererDrawRectangleOutline(position[0], position[1], size[0], size[1],
+                                     0, 0, 0, outlineWidth);
     vk2dRendererSetColourMod(VK2D_DEFAULT_COLOUR_MOD);
 }
 

--- a/src/engine/Renderer.hpp
+++ b/src/engine/Renderer.hpp
@@ -17,7 +17,8 @@ typedef std::vector<std::shared_ptr<IDrawable>> DrawableCollection;
 
 class Renderer {
 public:
-    Renderer(const std::string &name, int width, int height);
+    Renderer(const std::string &name, int width, int height,
+             bool debugRendering);
     ~Renderer();
 
     int init(bool debug);
@@ -26,6 +27,11 @@ public:
 
     static void drawRectangle(const Vector2 &position, const Vector2 &size,
                               const Color &color);
+
+    static void drawRectangleOutline(const Vector2 &position,
+                                     const Vector2 &size,
+                                     const float outlineWidth,
+                                     const Color &color);
 
     static void drawTexture(const Texture &texture, const Vector2 &position,
                             const Vector2 &scale);

--- a/src/engine/UI/DisplayLayout.cpp
+++ b/src/engine/UI/DisplayLayout.cpp
@@ -38,12 +38,21 @@ void DisplayLayout::render(const renderer::RendererContext &r) const {
         DisplayPosition pos = element->GetDisplayPosition();
         Vector2 displaySize = element->GetDisplaySize();
 
+        // Calculate the origin with respect to the matching positionOffset.
         Vector2 origin = GetOriginFromDisplayPosition(pos, displaySize, r);
         origin[0] += positionOffsets[pos];
 
         element->SetDisplayOrigin(origin);
+
+        // If debugging, render an outline around the UI Element.
+        if (r.renderDebugOutlines) {
+            renderer::Renderer::drawRectangleOutline(origin, displaySize, 2,
+                                                     Color::RED);
+        }
+
         element->Render(this->m_font);
 
+        // Update the matching positionOffset.
         if (pos == DisplayPosition::UpperRight ||
             pos == DisplayPosition::LowerRight) {
             positionOffsets[pos] -= displaySize[0];

--- a/src/engine/UI/DisplayLayout.cpp
+++ b/src/engine/UI/DisplayLayout.cpp
@@ -44,13 +44,13 @@ void DisplayLayout::render(const renderer::RendererContext &r) const {
 
         element->SetDisplayOrigin(origin);
 
+        element->Render(this->m_font);
+
         // If debugging, render an outline around the UI Element.
         if (r.renderDebugOutlines) {
             renderer::Renderer::drawRectangleOutline(origin, displaySize, 2,
                                                      Color::RED);
         }
-
-        element->Render(this->m_font);
 
         // Update the matching positionOffset.
         if (pos == DisplayPosition::UpperRight ||

--- a/src/engine/UI/DisplayLayout.cpp
+++ b/src/engine/UI/DisplayLayout.cpp
@@ -11,23 +11,24 @@ void DisplayLayout::AddElement(std::shared_ptr<Element> element) {
     m_elements.push_back(std::move(element));
 }
 
-static float GetHeightFromDisplayPosition(DisplayPosition pos,
-                                          const Vector2 &displaySize,
-                                          const Vector2 &windowSize) {
-    float height = 0;
+static Vector2
+GetOriginFromDisplayPosition(DisplayPosition pos, const Vector2 &displaySize,
+                             const renderer::RendererContext &r) {
+    Vector2 origin(0, 0);
 
-    switch (pos) {
-    case DisplayPosition::UpperLeft:
-    case DisplayPosition::UpperRight:
-        height = 0;
-        break;
-    case DisplayPosition::LowerLeft:
-    case DisplayPosition::LowerRight:
-        height = windowSize[1] - displaySize[1];
-        break;
+    // Fix right offset.
+    if (pos == DisplayPosition::UpperRight ||
+        pos == DisplayPosition::LowerRight) {
+        origin[0] = r.windowWidth - displaySize[0];
     }
 
-    return height;
+    // Fix lower offset.
+    if (pos == DisplayPosition::LowerLeft ||
+        pos == DisplayPosition::LowerRight) {
+        origin[1] = r.windowHeight - displaySize[1];
+    }
+
+    return origin;
 }
 
 void DisplayLayout::render(const renderer::RendererContext &r) const {
@@ -37,12 +38,18 @@ void DisplayLayout::render(const renderer::RendererContext &r) const {
         DisplayPosition pos = element->GetDisplayPosition();
         Vector2 displaySize = element->GetDisplaySize();
 
-        float startHeight = GetHeightFromDisplayPosition(
-            pos, displaySize, Vector2(r.windowWidth, r.windowHeight));
-        element->SetDisplayOrigin(Vector2(positionOffsets[pos], startHeight));
+        Vector2 origin = GetOriginFromDisplayPosition(pos, displaySize, r);
+        origin[0] += positionOffsets[pos];
+
+        element->SetDisplayOrigin(origin);
         element->Render(this->m_font);
 
-        positionOffsets[pos] += displaySize[0];
+        if (pos == DisplayPosition::UpperRight ||
+            pos == DisplayPosition::LowerRight) {
+            positionOffsets[pos] -= displaySize[0];
+        } else {
+            positionOffsets[pos] += displaySize[0];
+        }
     }
 }
 

--- a/src/test/gameObject.test.cpp
+++ b/src/test/gameObject.test.cpp
@@ -63,7 +63,7 @@ int check_quit() {
 
 int main(int argc, char *argv[]) {
     renderer::Renderer renderer =
-        renderer::Renderer("Admirals", WINDOW_WIDTH, WINDOW_HEIGHT);
+        renderer::Renderer("Admirals", WINDOW_WIDTH, WINDOW_HEIGHT, true);
     renderer.init(true);
 
     scene::Scene *scene = new scene::Scene();
@@ -86,7 +86,7 @@ int main(int argc, char *argv[]) {
     scene->addObject(scene::GameObject::createFromDerived(cell6));
 
     UI::DisplayLayout *layout = new UI::DisplayLayout();
-    UI::TextElement fpsText("Fps TextElement", "", Vector2(150, 40),
+    UI::TextElement fpsText("Fps TextElement", "", Vector2(500, 40),
                             Color::BLACK);
     fpsText.SetDisplayPosition(UI::DisplayPosition::LowerLeft);
     auto sharedFpsText = UI::Element::createFromDerived(fpsText);

--- a/src/test/renderer.test.cpp
+++ b/src/test/renderer.test.cpp
@@ -61,15 +61,24 @@ int main(int argc, char *argv[]) {
         TextureObject(Vector3(0, 0, 0), "assets/admirals.png");
     engine.AddGameObject(scene::GameObject::createFromDerived(textureObject));
 
-    Vector2 elementSize = Vector2(150, 40);
-    admirals::UI::Button testBtn("Test Button1", "Click Me!", elementSize,
-                                 Color::BLACK, Color::WHITE, OnButtonClick);
-    engine.AddUIElement(UI::Element::createFromDerived(testBtn));
+    Vector2 elementSize = Vector2(140, 40);
+    admirals::UI::Button testBtn("btn1", "Button 1", elementSize, Color::BLACK,
+                                 Color::WHITE, OnButtonClick);
 
-    admirals::UI::TextElement testText(
-        "Text Element1", "This is a text element.", elementSize, Color::BLACK);
-    testText.SetDisplayPosition(admirals::UI::DisplayPosition::LowerLeft);
-    engine.AddUIElement(std::make_shared<admirals::UI::TextElement>(testText));
+    admirals::UI::Button testBtn2("btn2", "Button 2", elementSize, Color::BLACK,
+                                  Color::WHITE, OnButtonClick);
+    engine.AddUIElement(UI::Element::createFromDerived(testBtn));
+    engine.AddUIElement(UI::Element::createFromDerived(testBtn2));
+
+    admirals::UI::TextElement testText1("textel1", "Left aligned",
+                                        Vector2(200, 40), Color::BLACK);
+    testText1.SetDisplayPosition(admirals::UI::DisplayPosition::LowerLeft);
+    engine.AddUIElement(UI::Element::createFromDerived(testText1));
+
+    admirals::UI::TextElement testText2("textel2", "Right aligned",
+                                        Vector2(210, 40), Color::BLACK);
+    testText2.SetDisplayPosition(admirals::UI::DisplayPosition::LowerRight);
+    engine.AddUIElement(UI::Element::createFromDerived(testText2));
 
     engine.StartGameLoop();
 


### PR DESCRIPTION
This PR fixes right-alignment rendering in DisplayLayout and also adds "debug rendering", which draws an outline around UI elements for debugging purposes, see images below.

With debugging enabled:
![image](https://github.com/joelsiks/admirals/assets/21147276/dd33ecdb-b375-44ab-ad7c-fdd3f769b759)

Without:
![image](https://github.com/joelsiks/admirals/assets/21147276/078ee682-51ba-4aa4-bbe1-0353cdbd4d82)

Also an image of the GameObject test:
![image](https://github.com/joelsiks/admirals/assets/21147276/9799cb3c-0336-419a-9114-80cd6b6e2cb4)


Closes #32 