### PR TITLE
Fixed OnStart/OnUpdate handling.

### DIFF
--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -25,7 +25,7 @@ void Engine::AddGameObject(std::shared_ptr<scene::GameObject> object) {
     m_scene->AddObject(object);
 }
 
-bool Engine::CheckQuit() {
+bool Engine::PollAndHandleEvent() {
     bool quit = false;
     SDL_Event e;
 
@@ -42,6 +42,8 @@ bool Engine::CheckQuit() {
 }
 
 void Engine::StartGameLoop() {
+    m_scene->OnStart();
+
     std::vector<std::shared_ptr<renderer::IDrawable>> layers;
     layers.emplace_back(m_scene);
     layers.emplace_back(m_displayLayout);
@@ -50,7 +52,8 @@ void Engine::StartGameLoop() {
     bool quit = false;
     SDL_Event e;
     while (!quit) {
-        quit = CheckQuit();
+        quit = PollAndHandleEvent();
+        m_scene->OnUpdate();
         m_renderer->Render(layers);
     }
 }

--- a/src/engine/Engine.hpp
+++ b/src/engine/Engine.hpp
@@ -22,7 +22,7 @@ public:
     void StartGameLoop();
 
 private:
-    bool CheckQuit();
+    bool PollAndHandleEvent();
 
     std::string m_gameName;
 

--- a/src/engine/GameObject.hpp
+++ b/src/engine/GameObject.hpp
@@ -17,8 +17,8 @@ public:
     inline Vector2 GetPosition() const { return m_position; }
     inline void SetPosition(const Vector2 &pos) { m_position = pos; }
 
-    virtual void OnUpdate() = 0;
     virtual void OnStart() = 0;
+    virtual void OnUpdate() = 0;
 
     virtual void Render(const renderer::RendererContext &r) const = 0;
 

--- a/src/engine/Scene.cpp
+++ b/src/engine/Scene.cpp
@@ -2,13 +2,24 @@
 
 using namespace admirals::scene;
 
+void Scene::AddObject(std::shared_ptr<GameObject> object) {
+    this->m_objects.Insert(std::move(object));
+}
+
 void Scene::Render(const renderer::RendererContext &r) const {
     for (const auto &object : this->m_objects) {
-        object->OnUpdate();
         object->Render(r);
     }
 }
 
-void Scene::AddObject(std::shared_ptr<GameObject> object) {
-    this->m_objects.Insert(std::move(object));
+void Scene::OnStart() {
+    for (const auto &object : this->m_objects) {
+        object->OnStart();
+    }
+}
+
+void Scene::OnUpdate() {
+    for (const auto &object : this->m_objects) {
+        object->OnUpdate();
+    }
 }

--- a/src/engine/Scene.hpp
+++ b/src/engine/Scene.hpp
@@ -13,9 +13,12 @@ namespace scene {
 
 class Scene : public renderer::IDrawable {
 public:
+    void AddObject(std::shared_ptr<GameObject> object);
+
     void Render(const renderer::RendererContext &r) const override;
 
-    void AddObject(std::shared_ptr<GameObject> object);
+    void OnStart();
+    void OnUpdate();
 
 private:
     OrderedCollection<GameObject> m_objects;


### PR DESCRIPTION
Before the changes in this PR, the render call in Scene took care of OnUpdate calls. This has now been moved into an OnUpdate call in the Scene and I've also added an OnStart call to the Scene that calls individual OnStart calls to the objects.