### PR TITLE
Initial implementation of menu systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set(SOURCES
     src/engine/UI/DisplayLayout.cpp
     src/engine/UI/Element.cpp
     src/engine/UI/Menu.cpp
+    src/engine/UI/MenuOption.cpp
     src/engine/UI/TextElement.cpp
     src/engine/GameObject.cpp
     src/engine/Scene.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,12 +26,14 @@ message("SDL2_INCLUDE_DIRS: ${SDL2_INCLUDE_DIR}")
 message("SDL2_LIBRARIES: ${SDL2_LIBRARIES}")
 message("Vulkan_INCLUDE_DIR: ${Vulkan_INCLUDE_DIR}")
 message("Vulkan_LIBRARIES: ${Vulkan_LIBRARIES}")
+message("CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
 
 set(SOURCES 
     src/engine/DataObjects.cpp
+    src/engine/UI/Button.cpp
     src/engine/UI/DisplayLayout.cpp
     src/engine/UI/Element.cpp
-    src/engine/UI/Button.cpp
+    src/engine/UI/Menu.cpp
     src/engine/UI/TextElement.cpp
     src/engine/GameObject.cpp
     src/engine/Scene.cpp
@@ -40,6 +42,12 @@ set(SOURCES
     src/engine/net/Connection.cpp
     src/engine/net/Client.cpp
     src/engine/net/Server.cpp
+)
+
+set(INCLUDE_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/engine/
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/engine/net
+    ${Vulkan_INCLUDE_DIR}
 )
 
 set(VMA_FILES ${VK2D_DIR}/VulkanMemoryAllocator/src/VmaUsage.cpp)
@@ -77,15 +85,13 @@ if(WIN32)
 endif()
 target_link_libraries(engine vk2d)
 target_link_libraries(engine asio)
-target_include_directories(engine PRIVATE 
-    "src/engine/" 
-)
+target_include_directories(engine PRIVATE ${INCLUDE_DIRS})
 
 # Create test executable
 add_executable(renderer_test src/test/renderer.test.cpp)
 target_link_libraries(renderer_test engine)
 target_include_directories(renderer_test PRIVATE 
-    "src/engine/"
+    ${INCLUDE_DIRS}
     "src/test/"
 )
 
@@ -93,7 +99,7 @@ target_include_directories(renderer_test PRIVATE
 add_executable(gameObject_test src/test/gameObject.test.cpp)
 target_link_libraries(gameObject_test engine)
 target_include_directories(gameObject_test PRIVATE 
-    "src/engine/"
+    ${INCLUDE_DIRS}
     "src/test/"
 )
     
@@ -101,23 +107,23 @@ target_include_directories(gameObject_test PRIVATE
 add_executable(test_client src/test/testclient.cpp)
 target_link_libraries(test_client engine)
 target_include_directories(test_client PRIVATE 
+    ${INCLUDE_DIRS}
     "src/test/"
-    "src/engine/net/"
 )
 
 # Test server
 add_executable(test_server src/test/testserver.cpp)
 target_link_libraries(test_server engine)
 target_include_directories(test_server PRIVATE 
+    ${INCLUDE_DIRS}
     "src/test/"
-    "src/engine/net/"
 )
 
 # Create test executable
 add_executable(depthOrderedCollection_text src/test/depthOrderedCollection.test.cpp)
 target_link_libraries(depthOrderedCollection_text engine)
 target_include_directories(depthOrderedCollection_text PRIVATE 
-    "src/engine/"
+    ${INCLUDE_DIRS}
     "src/test/"
 )
 
@@ -125,8 +131,8 @@ target_include_directories(depthOrderedCollection_text PRIVATE
 add_executable(scene_test src/test/scene.test.cpp)
 target_link_libraries(scene_test engine)
 target_include_directories(scene_test PRIVATE 
+    ${INCLUDE_DIRS}
     "src/test/"
-    "src/engine/"
 )
 
 # Copy SDL2.dll to the output directory after the executable is built

--- a/src/engine/DataObjects.cpp
+++ b/src/engine/DataObjects.cpp
@@ -58,6 +58,8 @@ const Color Color::GREEN = Color(0, 1, 0, 1);
 const Color Color::BLUE = Color(0, 0, 1, 1);
 const Color Color::WHITE = Color(1, 1, 1, 1);
 const Color Color::BLACK = Color(0, 0, 0, 1);
+const Color Color::GREY = Color::FromRGBA(80, 80, 80, 255);
+const Color Color::LIGHT_GREY = Color::FromRGBA(180, 180, 180, 255);
 
 // Texture
 Texture::Texture(VK2DTexture &m_texture) : m_texture(m_texture) {}

--- a/src/engine/DataObjects.hpp
+++ b/src/engine/DataObjects.hpp
@@ -153,6 +153,8 @@ public:
     const static Color BLUE;
     const static Color WHITE;
     const static Color BLACK;
+    const static Color GREY;
+    const static Color LIGHT_GREY;
 };
 
 class Texture {

--- a/src/engine/Engine.hpp
+++ b/src/engine/Engine.hpp
@@ -7,6 +7,7 @@
 #include "Scene.hpp"
 #include "UI/DisplayLayout.hpp"
 #include "UI/Element.hpp"
+#include "UI/Menu.hpp"
 
 namespace admirals {
 
@@ -15,12 +16,25 @@ public:
     Engine(const std::string &gameName, int windowWidth, int windowHeight,
            bool debug);
 
+    inline void SetEscapeMenu(std::shared_ptr<UI::Menu> menu) {
+        m_escapeMenu = menu;
+    }
+
     inline void AddUIElement(std::shared_ptr<UI::Element> element) {
         m_displayLayout->AddElement(element);
     }
 
     inline void AddGameObject(std::shared_ptr<scene::GameObject> object) {
         m_scene->AddObject(object);
+    }
+
+    inline void ToggleDebugRendering() { m_renderer->ToggleDebugRendering(); }
+
+    template <typename T, typename... _Args>
+    inline std::shared_ptr<T> MakeAndSetEscapeMenu(_Args &&..._args) {
+        auto object = std::make_shared<T>(_args...);
+        SetEscapeMenu(object);
+        return object;
     }
 
     template <typename T, typename... _Args>
@@ -38,13 +52,19 @@ public:
     }
 
     void StartGameLoop();
+    inline void StopGameLoop() { m_running = false; }
 
 private:
     bool PollAndHandleEvent();
 
+    bool m_running;
+
     std::string m_gameName;
 
+    bool m_showingMenus = false;
+
     // Drawables
+    std::shared_ptr<UI::Menu> m_escapeMenu;
     std::shared_ptr<UI::DisplayLayout> m_displayLayout;
     std::shared_ptr<scene::Scene> m_scene;
 

--- a/src/engine/OrderedCollection.hpp
+++ b/src/engine/OrderedCollection.hpp
@@ -44,18 +44,13 @@ public:
     /// the same order as the `IOrdered::name` values are sorted in the ordered
     /// multiset.
     struct Iterator {
-        Iterator(OrderedKeySet::iterator i, const KeyToPointerMap &m_objects)
-            : m_iter(i), m_objects(m_objects) {}
+        Iterator(OrderedKeySet::iterator i, const KeyToPointerMap &objects)
+            : m_iter(i), m_objects(objects) {}
 
         const std::shared_ptr<T> operator*() const {
             auto v = (m_iter.operator*)();
             return m_objects.at(v);
         }
-
-        // std::shared_ptr<T> operator->() {
-        //     auto v = (m_iter.operator*)();
-        //     return m_objects.at(v);
-        // }
 
         Iterator &operator++() {
             m_iter++;
@@ -81,10 +76,58 @@ public:
         const KeyToPointerMap &m_objects;
     };
 
+    /// @brief Iterates over the `IOrdered` object points in the collection in
+    /// the reverse order as the `IOrdered::name` values are sorted in the
+    /// ordered multiset.
+    struct ReverseIterator {
+        ReverseIterator(OrderedKeySet::reverse_iterator i,
+                        const KeyToPointerMap &objects)
+            : m_revIter(i), m_objects(objects) {}
+
+        const std::shared_ptr<T> operator*() const {
+            auto v = (m_revIter.operator*)();
+            return m_objects.at(v);
+        }
+
+        ReverseIterator &operator++() {
+            m_revIter++;
+            return *this;
+        }
+
+        ReverseIterator operator++(int) {
+            ReverseIterator tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        friend bool operator==(const ReverseIterator &a,
+                               const ReverseIterator &b) {
+            return a.m_revIter == b.m_revIter;
+        };
+
+        friend bool operator!=(const ReverseIterator &a,
+                               const ReverseIterator &b) {
+            return a.m_revIter != b.m_revIter;
+        };
+
+    private:
+        OrderedKeySet::reverse_iterator m_revIter;
+        const KeyToPointerMap &m_objects;
+    };
+
     /// @brief Iterator starting at the start of the ordered collection.
     Iterator begin() const { return Iterator(m_ordered.begin(), m_objects); }
     /// @brief Iterator at the end of the ordered collection.
     Iterator end() const { return Iterator(m_ordered.end(), m_objects); }
+
+    /// @brief Iterator starting at the end of the ordered collection.
+    ReverseIterator rbegin() const {
+        return ReverseIterator(m_ordered.rbegin(), m_objects);
+    }
+    /// @brief Iterator at the start of the ordered collection.
+    ReverseIterator rend() const {
+        return ReverseIterator(m_ordered.rend(), m_objects);
+    }
 
     /// @brief Inserts an `IOrdered` object pointer into the collection if no
     /// other contained object has the same`IOrdered::name` property.

--- a/src/engine/Renderer.cpp
+++ b/src/engine/Renderer.cpp
@@ -1,10 +1,10 @@
+#include <cmath>
+
 #include <VK2D/Constants.h>
 #include <VK2D/Renderer.h>
-#include <cmath>
 
 #include "DataObjects.hpp"
 #include "Renderer.hpp"
-#include <cmath>
 
 using namespace admirals::renderer;
 
@@ -69,6 +69,13 @@ void Renderer::Render(const DrawableCollection &drawable) {
         d->Render(m_context);
     }
     vk2dRendererEndFrame();
+}
+
+void Renderer::DrawLine(const Vector2 &p1, const Vector2 &p2,
+                        const Color &color) {
+    vk2dRendererSetColourMod(color.Data());
+    vk2dRendererDrawLine(p1[0], p1[1], p2[0], p2[1]);
+    vk2dRendererSetColourMod(VK2D_DEFAULT_COLOUR_MOD);
 }
 
 void Renderer::DrawRectangle(const Vector2 &position, const Vector2 &size,

--- a/src/engine/Renderer.hpp
+++ b/src/engine/Renderer.hpp
@@ -24,7 +24,14 @@ public:
     int Init(bool debug);
     void Render(const DrawableCollection &drawable);
 
+    inline void ToggleDebugRendering() {
+        m_context.renderDebugOutlines = !m_context.renderDebugOutlines;
+    }
+
     inline RendererContext context() const { return m_context; }
+
+    static void DrawLine(const Vector2 &p1, const Vector2 &p2,
+                         const Color &color);
 
     static void DrawRectangle(const Vector2 &position, const Vector2 &size,
                               const Color &color);

--- a/src/engine/UI/Button.cpp
+++ b/src/engine/UI/Button.cpp
@@ -1,4 +1,4 @@
-#include "Button.hpp"
+#include "UI/Button.hpp"
 #include "Renderer.hpp"
 
 using namespace admirals::UI;

--- a/src/engine/UI/Button.hpp
+++ b/src/engine/UI/Button.hpp
@@ -2,8 +2,8 @@
 
 #include <functional>
 
-#include "Element.hpp"
 #include "EventSystem.hpp"
+#include "UI/Element.hpp"
 
 namespace admirals::UI {
 

--- a/src/engine/UI/DisplayLayout.cpp
+++ b/src/engine/UI/DisplayLayout.cpp
@@ -4,28 +4,39 @@
 using namespace admirals;
 using namespace admirals::UI;
 
+static const char *FONT_PATH = "assets/font.png";
+static const float FONT_CHAR_WIDTH = 16.0;
+static const float FONT_CHAR_HEIGHT = 36.0;
+
 DisplayLayout::DisplayLayout()
-    : m_font(Texture::LoadFromPath("assets/font.png")) {}
+    : m_font(Texture::LoadFromPath(FONT_PATH)), m_fontWidth(FONT_CHAR_WIDTH),
+      m_fontHeight(FONT_CHAR_HEIGHT) {}
 
 void DisplayLayout::AddElement(std::shared_ptr<Element> element) {
     this->m_elements.Insert(std::move(element));
 }
 
-static Vector2
-GetOriginFromDisplayPosition(DisplayPosition pos, const Vector2 &displaySize,
-                             const renderer::RendererContext &r) {
+Vector2 DisplayLayout::GetOriginFromDisplayPosition(
+    DisplayPosition pos, const Vector2 &displaySize,
+    const renderer::RendererContext &r) {
     Vector2 origin(0, 0);
+
+    // Handle center.
+    if (pos == DisplayPosition::Center) {
+        origin[0] = ((float)r.windowWidth - displaySize[0]) / 2.0;
+        return origin;
+    }
 
     // Fix right offset.
     if (pos == DisplayPosition::UpperRight ||
         pos == DisplayPosition::LowerRight) {
-        origin[0] = r.windowWidth - displaySize[0];
+        origin[0] = (float)r.windowWidth - displaySize[0];
     }
 
     // Fix lower offset.
     if (pos == DisplayPosition::LowerLeft ||
         pos == DisplayPosition::LowerRight) {
-        origin[1] = r.windowHeight - displaySize[1];
+        origin[1] = (float)r.windowHeight - displaySize[1];
     }
 
     return origin;
@@ -35,7 +46,7 @@ void DisplayLayout::Render(const renderer::RendererContext &r) const {
     Vector4 positionOffsets = Vector4(0);
 
     for (const auto &element : m_elements) {
-        DisplayPosition pos = element->GetDisplayPosition();
+        const DisplayPosition pos = element->GetDisplayPosition();
         Vector2 displaySize = element->GetDisplaySize();
 
         // Calculate the origin with respect to the matching positionOffset.

--- a/src/engine/UI/DisplayLayout.cpp
+++ b/src/engine/UI/DisplayLayout.cpp
@@ -1,4 +1,4 @@
-#include "DisplayLayout.hpp"
+#include "UI/DisplayLayout.hpp"
 #include "Renderer.hpp"
 
 using namespace admirals;

--- a/src/engine/UI/DisplayLayout.hpp
+++ b/src/engine/UI/DisplayLayout.hpp
@@ -3,9 +3,9 @@
 #include <memory>
 #include <vector>
 
-#include "Element.hpp"
 #include "InteractiveDrawable.hpp"
 #include "OrderedCollection.hpp"
+#include "UI/Element.hpp"
 
 namespace admirals::UI {
 

--- a/src/engine/UI/DisplayLayout.hpp
+++ b/src/engine/UI/DisplayLayout.hpp
@@ -18,8 +18,19 @@ public:
 
     void AddElement(std::shared_ptr<Element> element);
 
-private:
+    static Vector2
+    GetOriginFromDisplayPosition(DisplayPosition pos,
+                                 const Vector2 &displaySize,
+                                 const renderer::RendererContext &r);
+
+    inline Vector2 TextFontSize(const std::string &text) const {
+        return Vector2((float)text.length() * m_fontWidth, m_fontHeight);
+    }
+
+protected:
     Texture m_font;
+    float m_fontWidth, m_fontHeight;
+
     OrderedCollection<Element> m_elements;
 };
 

--- a/src/engine/UI/Element.cpp
+++ b/src/engine/UI/Element.cpp
@@ -1,4 +1,4 @@
-#include "Element.hpp"
+#include "UI/Element.hpp"
 
 using namespace admirals::UI;
 

--- a/src/engine/UI/Element.hpp
+++ b/src/engine/UI/Element.hpp
@@ -16,6 +16,7 @@ enum DisplayPosition {
     UpperRight = 1,
     LowerLeft = 2,
     LowerRight = 3,
+    Center = 4,
 };
 
 // General UI element that can be rendered.

--- a/src/engine/UI/Menu.cpp
+++ b/src/engine/UI/Menu.cpp
@@ -1,0 +1,69 @@
+#include <format>
+
+#include "DataObjects.hpp"
+#include "Menu.hpp"
+#include "Renderer.hpp"
+#include "UI/Menu.hpp"
+
+using namespace admirals::UI;
+
+Menu::Menu(const std::string &menuTitle, const Color &foregroundColor)
+    : m_menuTitle(menuTitle), m_fgColor(foregroundColor) {
+
+    const TextOption titleOption(MENU_TITLE_NAME, Menu::commonDepthOrder,
+                                 menuTitle);
+
+    this->AddMenuOption(MenuOption::CreateFromDerived(titleOption));
+}
+
+void Menu::AddMenuOption(const std::shared_ptr<MenuOption> &menuOption) {
+    menuOption->SetDisplayPosition(DisplayPosition::Center);
+
+    this->AddElement(static_cast<std::shared_ptr<Element>>(menuOption));
+}
+
+void Menu::Render(const renderer::RendererContext &r) const {
+
+    float centerPositionOffset = 0;
+
+    // Draw background.
+    renderer::Renderer::DrawRectangle(
+        Vector2(0, 0), Vector2((float)r.windowWidth, (float)r.windowHeight),
+        Color::LIGHT_GREY);
+
+    for (auto it = m_elements.rbegin(); it != m_elements.rend(); ++it) {
+        auto option = std::dynamic_pointer_cast<MenuOption>(*it);
+
+        const DisplayPosition pos = option->GetDisplayPosition();
+        Vector2 displaySize = option->GetDisplaySize();
+
+        // Calculate the origin with respect to the matching positionOffset.
+        Vector2 origin =
+            DisplayLayout::GetOriginFromDisplayPosition(pos, displaySize, r);
+        origin[1] += centerPositionOffset;
+
+        // Update menu-dependent state of the options.
+        option->SetDisplaySize(TextFontSize(option->GetOptionText()));
+        option->SetTextColor(m_fgColor);
+
+        option->SetDisplayOrigin(origin);
+        option->Render(this->m_font);
+
+        // If we're rendering the menu title, add a line below it.
+        if (option->name() == MENU_TITLE_NAME) {
+            renderer::Renderer::DrawLine(
+                Vector2(origin[0], origin[1] + displaySize[1]),
+                Vector2(origin[0] + displaySize[0], origin[1] + displaySize[1]),
+                m_fgColor);
+            centerPositionOffset += MENU_TITLE_LINE_OFFSET;
+        }
+
+        // If debugging, render an outline around the UI Element.
+        if (r.renderDebugOutlines) {
+            renderer::Renderer::DrawRectangleOutline(origin, displaySize, 2,
+                                                     Color::RED);
+        }
+
+        centerPositionOffset += displaySize[1];
+    }
+}

--- a/src/engine/UI/Menu.hpp
+++ b/src/engine/UI/Menu.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <memory>
+
+#include "EventSystem.hpp"
+#include "UI/DisplayLayout.hpp"
+#include "UI/MenuOption.hpp"
+
+namespace admirals::UI {
+
+class Menu : public DisplayLayout {
+public:
+    Menu(const std::string &menuTitle, const Color &foregroundColor);
+
+    void AddMenuOption(const std::shared_ptr<MenuOption> &menuOption);
+
+    void Render(const renderer::RendererContext &r) const override;
+
+    inline void SetTextColor(const Color &color) { m_fgColor = color; }
+
+    template <typename T, typename... _Args>
+    inline std::shared_ptr<T> MakeMenuOption(_Args &&..._args) {
+        auto object = std::make_shared<T>(_args...);
+        AddMenuOption(object);
+        return object;
+    }
+
+private:
+    static constexpr float commonDepthOrder = 10;
+
+    Color m_fgColor;
+    std::string m_menuTitle;
+};
+
+} // namespace admirals::UI

--- a/src/engine/UI/MenuOption.cpp
+++ b/src/engine/UI/MenuOption.cpp
@@ -1,0 +1,119 @@
+#include <format>
+
+#include "MenuOption.hpp"
+#include "Renderer.hpp"
+
+using namespace admirals::UI;
+
+void MenuOptionClickBackground(void *sender, OptionClickEventArgs &event) {
+    auto *option = static_cast<MenuOption *>(sender);
+
+    if (event.m_data.type == SDL_MOUSEBUTTONUP) {
+        option->SetDrawBackground(false);
+    } else if (event.m_data.type == SDL_MOUSEBUTTONDOWN) {
+        option->SetDrawBackground(true);
+    }
+}
+
+// MenuOption
+MenuOption::MenuOption(const std::string &name, float order,
+                       const std::string &text)
+    : Element(name, order, text, Vector2(0, 0)) {
+    onClick.Subscribe(MenuOptionClickBackground);
+}
+
+void MenuOption::Render(const Texture &font) {
+    if (m_clickedAndShouldDrawBackground) {
+        renderer::Renderer::DrawRectangle(m_displayOrigin, m_displaySize,
+                                          Color::GREY);
+    }
+
+    renderer::Renderer::DrawText(font, m_displayOrigin, m_textColor,
+                                 GetOptionText());
+}
+
+bool MenuOption::HandleEvent(const SDL_Event &event) {
+    if (event.type == SDL_MOUSEBUTTONDOWN || event.type == SDL_MOUSEBUTTONUP) {
+
+        const float mouseX = (float)event.button.x;
+        const float mouseY = (float)event.button.y;
+
+        if (mouseX >= m_displayOrigin[0] &&
+            mouseX <= m_displayOrigin[0] + m_displaySize[0] &&
+            mouseY >= m_displayOrigin[1] &&
+            mouseY <= m_displayOrigin[1] + m_displaySize[1]) {
+
+            // call click handler.
+            OptionClickEventArgs e = OptionClickEventArgs(event);
+            onClick.Invoke(this, e);
+
+            return true;
+        } else if (m_clickedAndShouldDrawBackground &&
+                   event.type == SDL_MOUSEBUTTONUP) {
+            SetDrawBackground(false);
+        }
+    }
+
+    return false;
+}
+
+// TextOption
+TextOption::TextOption(const std::string &name, float order,
+                       const std::string &text)
+    : MenuOption(name, order, text) {}
+
+std::string TextOption::GetOptionText() { return m_text; }
+
+// ClickOption
+ClickOption::ClickOption(const std::string &name, float order,
+                         const std::string &text)
+    : MenuOption(name, order, text) {}
+
+std::string ClickOption::GetOptionText() { return m_text; }
+
+// ToggleOption
+ToggleOption::ToggleOption(const std::string &name, float order,
+                           const std::string &text, bool startToggled)
+    : MenuOption(name, order, text), m_toggled(startToggled) {
+
+    onClick.Subscribe([](void *sender, OptionClickEventArgs &e) {
+        if (e.m_data.type != SDL_MOUSEBUTTONUP)
+            return;
+
+        auto *toggleOption = static_cast<ToggleOption *>(sender);
+        toggleOption->Toggle();
+    });
+}
+
+std::string ToggleOption::GetOptionText() {
+    return std::format("{} [{}]", m_text, m_toggled ? "ON" : "OFF");
+}
+
+void ToggleOption::Toggle() { m_toggled = !m_toggled; }
+
+// CycleOption
+CycleOption::CycleOption(const std::string &name, float order,
+                         const std::string &text,
+                         const std::vector<std::string> &cycleOptions,
+                         size_t startIndex)
+    : MenuOption(name, order, text), m_cycleOptions(cycleOptions),
+      m_currentOption(startIndex) {
+
+    onClick.Subscribe([](void *sender, OptionClickEventArgs &e) {
+        if (e.m_data.type != SDL_MOUSEBUTTONUP)
+            return;
+
+        auto *cycleOption = static_cast<CycleOption *>(sender);
+        cycleOption->Cycle();
+    });
+}
+
+std::string CycleOption::GetOptionText() {
+    return std::format("{} [{}]", m_text, m_cycleOptions[CurrentIndex()]);
+}
+
+void CycleOption::Cycle() {
+    m_currentOption = (m_currentOption + 1) % m_cycleOptions.size();
+}
+
+size_t CycleOption::CurrentIndex() const { return m_currentOption; }

--- a/src/engine/UI/MenuOption.hpp
+++ b/src/engine/UI/MenuOption.hpp
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "DataObjects.hpp"
+#include "EventSystem.hpp"
+#include "UI/Element.hpp"
+
+namespace admirals::UI {
+
+static const char *MENU_TITLE_NAME = "__OPTION_TITLE_NAME";
+static const float MENU_TITLE_LINE_OFFSET = 10;
+
+class OptionClickEventArgs : public events::EventArgs {
+public:
+    OptionClickEventArgs(const SDL_Event &data) : m_data(data) {}
+    const SDL_Event m_data;
+};
+
+class MenuOption : public Element {
+public:
+    events::EventSystem<OptionClickEventArgs> onClick;
+
+    MenuOption(const std::string &name, float order, const std::string &text);
+
+    void Render(const Texture &font) override;
+
+    bool HandleEvent(const SDL_Event &event) override;
+
+    virtual std::string GetOptionText() = 0;
+    inline void SetTextColor(const Color &color) { m_textColor = color; }
+
+    inline void SetDrawBackground(bool value) {
+        m_clickedAndShouldDrawBackground = value;
+    }
+
+    template <typename T>
+    static std::shared_ptr<MenuOption>
+    CreateFromDerived(const T &derivedObject) {
+        // Assuming T is derived from Element
+        std::shared_ptr<MenuOption> element =
+            std::make_shared<T>(derivedObject);
+        return element;
+    }
+
+private:
+    Color m_textColor;
+    bool m_clickedAndShouldDrawBackground = false;
+};
+
+// Text Option, is non-interactive.
+class TextOption : public MenuOption {
+public:
+    TextOption(const std::string &name, float order, const std::string &text);
+
+    std::string GetOptionText() override;
+};
+
+// Click Option, click and event occurs (Close, Exit)
+class ClickOption : public MenuOption {
+public:
+    ClickOption(const std::string &name, float order, const std::string &text);
+
+    std::string GetOptionText() override;
+};
+
+// Toggle Option, click and toggle between two states (ON/OFF)
+class ToggleOption : public MenuOption {
+public:
+    ToggleOption(const std::string &name, float order, const std::string &text,
+                 bool startToggled);
+
+    std::string GetOptionText() override;
+
+    void Toggle();
+
+private:
+    bool m_toggled;
+};
+
+// Cycle Option, click and cycle through some list of states (1/2/3/4...)
+class CycleOption : public MenuOption {
+public:
+    CycleOption(const std::string &name, float order, const std::string &text,
+                const std::vector<std::string> &cycleOptions,
+                size_t startIndex);
+
+    std::string GetOptionText() override;
+
+    void Cycle();
+    size_t CurrentIndex() const;
+
+private:
+    size_t m_currentOption;
+    std::vector<std::string> m_cycleOptions;
+};
+
+} // namespace admirals::UI

--- a/src/engine/UI/TextElement.cpp
+++ b/src/engine/UI/TextElement.cpp
@@ -1,4 +1,4 @@
-#include "TextElement.hpp"
+#include "UI/TextElement.hpp"
 #include "Renderer.hpp"
 
 using namespace admirals::UI;

--- a/src/engine/UI/TextElement.hpp
+++ b/src/engine/UI/TextElement.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Element.hpp"
+#include "UI/Element.hpp"
 
 namespace admirals {
 namespace UI {


### PR DESCRIPTION
This is a pretty significant PR (sorry).

I'll start by naming the changes that are separable from the menu system:
* Made UI includes consistent and moved engine includes to a defined variable in `CMakeLists.txt`
* Implemented `rbegin()/rend()` with a `ReverseIterator` for `OrderedCollection`

To the menu system, where the main new additions are the `Menu` and `MenuOption` (with subclasses). `Menu` inherits from `DisplayLayout` and in many cases works the same, except that is stores `MenuOptions` and the `Render` call is a bit different which does some specific things for `MenuOptions`.

A `MenuOption` is one of four subclasses: `TextOption`, `ClickOption`, `ToggleOption` and `CycleOption` (inspired from Minecraft menus).

Lastly I have also refactored and implemented a menu for the renderer test.

Closes #51 