### PR TITLE
MVP Start menu

### DIFF
--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -50,7 +50,10 @@ bool Engine::PollAndHandleEvent() {
 
 void Engine::StartGameLoop() {
     m_running = true;
-    m_scene->OnStart();
+
+    if (hasScene()) {
+        m_scene->OnStart();
+    }
 
     std::vector<std::shared_ptr<renderer::IDrawable>> layers(2);
 

--- a/src/engine/Engine.hpp
+++ b/src/engine/Engine.hpp
@@ -77,6 +77,11 @@ public:
     void StartGameLoop();
     inline void StopGameLoop() { m_running = false; }
 
+    inline Vector2 GetWindowSize() {
+        auto rctx = m_renderer->Context();
+        return Vector2(rctx.windowWidth, rctx.windowHeight);
+    }
+
 private:
     bool PollAndHandleEvent();
 

--- a/src/engine/Engine.hpp
+++ b/src/engine/Engine.hpp
@@ -37,8 +37,8 @@ public:
         auto currentScene = m_scene;
         m_scene = scene;
 
-        if (hasScene() && !scene->IsInitialized()) {
-            scene->OnStart();
+        if (hasScene() && !m_scene->IsInitialized()) {
+            m_scene->OnStart();
         }
 
         return currentScene;

--- a/src/engine/Engine.hpp
+++ b/src/engine/Engine.hpp
@@ -36,6 +36,11 @@ public:
     SetAndGetScene(const std::shared_ptr<scene::Scene> &scene) {
         auto currentScene = m_scene;
         m_scene = scene;
+
+        if (scene != nullptr && !scene->IsInitialized()) {
+            scene->OnStart();
+        }
+
         return currentScene;
     }
 

--- a/src/engine/Engine.hpp
+++ b/src/engine/Engine.hpp
@@ -37,7 +37,7 @@ public:
         auto currentScene = m_scene;
         m_scene = scene;
 
-        if (scene != nullptr && !scene->IsInitialized()) {
+        if (hasScene() && !scene->IsInitialized()) {
             scene->OnStart();
         }
 

--- a/src/engine/Scene.cpp
+++ b/src/engine/Scene.cpp
@@ -54,6 +54,8 @@ std::vector<std::string> Scene::GetSceneObjectNames() {
 }
 
 void Scene::OnStart() {
+    m_isInitialized = true;
+
     for (const auto &object : this->m_objects) {
         object->OnStart();
     }

--- a/src/engine/Scene.hpp
+++ b/src/engine/Scene.hpp
@@ -24,8 +24,11 @@ public:
     void OnStart();
     void OnUpdate();
 
+    bool IsInitialized() const { return m_isInitialized; }
+
 private:
     OrderedCollection<GameObject> m_objects;
+    bool m_isInitialized;
 };
 
 } // namespace admirals::scene

--- a/src/engine/UI/menu/Menu.cpp
+++ b/src/engine/UI/menu/Menu.cpp
@@ -5,9 +5,9 @@
 using namespace admirals::UI::menu;
 
 Menu::Menu(const std::string &menuTitle, const Color &foregroundColor,
-           const Color &backgroundColor)
+           const Color &backgroundColor, float topPadding)
     : m_menuTitle(menuTitle), m_fgColor(foregroundColor),
-      m_bgColor(backgroundColor) {
+      m_bgColor(backgroundColor), m_topPadding(topPadding) {
 
     const TextOption titleOption(MENU_TITLE_NAME, Menu::commonDepthOrder,
                                  menuTitle);
@@ -23,7 +23,7 @@ void Menu::AddMenuOption(const std::shared_ptr<MenuOption> &menuOption) {
 
 void Menu::Render(const renderer::RendererContext &r) const {
 
-    float centerPositionOffset = 0;
+    float centerPositionOffset = m_topPadding;
 
     // Draw background.
     renderer::Renderer::DrawRectangle(

--- a/src/engine/UI/menu/Menu.hpp
+++ b/src/engine/UI/menu/Menu.hpp
@@ -11,7 +11,7 @@ namespace admirals::UI::menu {
 class Menu : public DisplayLayout {
 public:
     Menu(const std::string &menuTitle, const Color &foregroundColor,
-         const Color &backgroundColor);
+         const Color &backgroundColor, float topPadding = 0);
 
     void AddMenuOption(const std::shared_ptr<MenuOption> &menuOption);
 
@@ -29,8 +29,9 @@ public:
 private:
     static constexpr float commonDepthOrder = 10;
 
-    Color m_fgColor, m_bgColor;
     std::string m_menuTitle;
+    Color m_fgColor, m_bgColor;
+    float m_topPadding;
 };
 
 } // namespace admirals::UI::menu

--- a/src/mvp/objects/Background.cpp
+++ b/src/mvp/objects/Background.cpp
@@ -13,9 +13,7 @@ void Background::OnStart() {}
 void Background::OnUpdate() {}
 
 void Background::Render(const renderer::RendererContext &r) const {
-    Vector2 offset = Vector2(r.windowWidth - GameData::GridSize,
-                             r.windowHeight - GameData::GridSize) /
-                     2;
-    renderer::Renderer::DrawRectangle(offset, Vector2(GameData::GridSize),
-                                      m_color);
+    const Vector2 size = Vector2(static_cast<float>(r.windowWidth),
+                                 static_cast<float>(r.windowHeight));
+    renderer::Renderer::DrawRectangle(Vector2(0, 0), size, m_color);
 }

--- a/src/mvp/objects/MenuMovingShip.hpp
+++ b/src/mvp/objects/MenuMovingShip.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <chrono>
+
+#include "Ship.hpp"
+#include "Sprite.hpp"
+#include "commontypes.hpp"
+
+static const float SECONDS_PER_MICROSECOND = 1000000.0f;
+
+namespace admirals::mvp::objects {
+
+class MenuMovingShip : public Sprite {
+public:
+    MenuMovingShip(const std::string &name, const Vector2 &position,
+                   const Vector2 &size, const Texture &source,
+                   ShipType::ShipType type, float shipSpeed)
+        : Sprite(name, 3, position, size, source,
+                 Ship::ShipTypeToTexOffset(type)),
+          m_size(size), m_shipSpeed(shipSpeed) {}
+
+    void OnStart() override {
+        m_time = std::chrono::high_resolution_clock::now();
+    }
+
+    void OnUpdate() override {
+        auto time = std::chrono::high_resolution_clock::now();
+        float deltaTime =
+            std::chrono::duration_cast<std::chrono::microseconds>(time - m_time)
+                .count() /
+            SECONDS_PER_MICROSECOND;
+
+        Vector2 position = this->GetPosition();
+        Vector2 windowSize = GameData::engine->GetWindowSize();
+
+        float newX = position.x() + m_shipSpeed * deltaTime;
+        if (newX > windowSize[0]) {
+            newX = -m_size.x();
+        }
+
+        position.SetX(newX);
+        this->SetPosition(position);
+        m_time = time;
+    }
+
+private:
+    Vector2 m_size;
+    float m_windowWidth;
+    std::chrono::_V2::system_clock::time_point m_time;
+
+    float m_shipSpeed;
+};
+
+} // namespace admirals::mvp::objects

--- a/src/mvp/shared.cpp
+++ b/src/mvp/shared.cpp
@@ -3,6 +3,9 @@
 using namespace admirals;
 using namespace admirals::mvp;
 
+std::shared_ptr<UI::menu::Menu> GameData::startMenu = nullptr;
+std::shared_ptr<scene::Scene> GameData::startMenuScene = nullptr;
+
 std::unique_ptr<Engine> GameData::engine = nullptr;
 const float GameData::CellSize = 64;
 const int GameData::GridCells = 10;

--- a/src/mvp/shared.hpp
+++ b/src/mvp/shared.hpp
@@ -1,7 +1,9 @@
 #pragma once
+
 #include <memory>
 
 #include "Engine.hpp"
+#include "UI/menu/Menu.hpp"
 
 namespace admirals::mvp {
 
@@ -10,6 +12,9 @@ private:
 public:
     GameData(){};
     ~GameData(){};
+
+    static std::shared_ptr<UI::menu::Menu> startMenu;
+    static std::shared_ptr<scene::Scene> startMenuScene;
 
     static std::unique_ptr<Engine> engine;
     static const float CellSize;


### PR DESCRIPTION
This PR implements a start menu for the MVP that is displayed when the game starts.
Additional changes are correctly handling uninitialized scenes being passed to `SetAndGetScene()` and also adding `topPadding` configuration to menus that simply initialized the `centerOffsetPosition` in the `Renderer()` method.

For clarification, the ships in the image below are moving horizontally on the screen.
![image](https://github.com/joelsiks/admirals/assets/21147276/4d626798-8bae-45da-8384-f6d074b71426)

Closes #62 