### PR TITLE
Engine context with DeltaTime

### DIFF
--- a/src/engine/Context.hpp
+++ b/src/engine/Context.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <chrono>
+
+namespace admirals {
+
+class Context {
+public:
+    Context() : m_deltaTime(0.0) {
+        m_lastTime = std::chrono::high_resolution_clock::now();
+    }
+    Context(const Context &) = delete;
+    ~Context() {}
+
+    void UpdateDelta() {
+        std::chrono::time_point<std::chrono::high_resolution_clock> now =
+            std::chrono::high_resolution_clock::now();
+        m_deltaTime = std::chrono::duration<double>(now - m_lastTime).count();
+        m_lastTime = now;
+    }
+    double DeltaTime() const { return m_deltaTime; }
+
+    int windowWidth;
+    int windowHeight;
+
+    // Indicates whether to draw outlines of elements for debugging purposes.
+    bool renderDebugOutlines;
+
+private:
+    double m_deltaTime;
+    std::chrono::time_point<std::chrono::high_resolution_clock> m_lastTime;
+};
+
+} // namespace admirals

--- a/src/engine/DataObjects.hpp
+++ b/src/engine/DataObjects.hpp
@@ -69,7 +69,7 @@ public:
     }
 
     inline Vector2 operator-(const Vector2 &r) const {
-        return Vector2(m_0 + r.m_0, m_1 + r.m_1);
+        return Vector2(m_0 - r.m_0, m_1 - r.m_1);
     }
 
     inline Vector2 &operator-=(const Vector2 &r) {
@@ -190,7 +190,7 @@ public:
     }
 
     inline Vector3 operator-(const Vector3 &r) const {
-        return Vector3(m_0 + r.m_0, m_1 + r.m_1, m_2 + r.m_2);
+        return Vector3(m_0 - r.m_0, m_1 - r.m_1, m_2 - r.m_2);
     }
 
     inline Vector3 &operator-=(const Vector3 &r) {
@@ -322,7 +322,7 @@ public:
     }
 
     inline Vector4 operator-(const Vector4 &r) const {
-        return Vector4(m_0 + r.m_0, m_1 + r.m_1, m_2 + r.m_2, m_3 + r.m_3);
+        return Vector4(m_0 - r.m_0, m_1 - r.m_1, m_2 - r.m_2, m_3 - r.m_3);
     }
 
     inline Vector4 &operator-=(const Vector4 &r) {
@@ -427,6 +427,7 @@ public:
     // should be uint32
     float Width() const;
     float Height() const;
+    inline Vector2 Size() const { return Vector2(Width(), Height()); };
     VK2DTexture Data() const { return m_texture; }
 
     static Texture LoadFromPath(const std::string &path);

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -5,11 +5,15 @@ using namespace admirals::events;
 
 Engine::Engine(const std::string &gameName, int windowWidth, int windowHeight,
                bool debug) {
+    m_context = std::make_unique<Context>();
+    m_context->windowWidth = windowWidth;
+    m_context->windowHeight = windowHeight;
+    m_context->renderDebugOutlines = debug;
     m_renderer = std::make_shared<renderer::Renderer>(gameName, windowWidth,
                                                       windowHeight, debug);
     // Initialize the renderer right after creating it. Necessary in cases where
     // DisplayLayout requires vk2d to be initialized.
-    m_renderer->Init(debug);
+    m_renderer->Init(windowWidth, windowHeight, debug);
 
     m_displayLayout = std::make_shared<UI::DisplayLayout>();
 
@@ -52,7 +56,7 @@ void Engine::StartGameLoop() {
     m_running = true;
 
     if (hasScene()) {
-        m_scene->OnStart();
+        m_scene->OnStart(*m_context);
     }
 
     std::vector<std::shared_ptr<renderer::IDrawable>> layers(2);
@@ -63,12 +67,14 @@ void Engine::StartGameLoop() {
         layers[0] = m_scene;
         layers[1] = m_displayLayout;
 
+        m_context->UpdateDelta();
+
         quit = PollAndHandleEvent();
 
         if (hasScene()) {
-            m_scene->OnUpdate();
+            m_scene->OnUpdate(*m_context);
         }
 
-        m_renderer->Render(layers);
+        m_renderer->Render(*m_context, layers);
     }
 }

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -4,11 +4,11 @@ using namespace admirals;
 using namespace admirals::events;
 
 Engine::Engine(const std::string &gameName, int windowWidth, int windowHeight,
-               bool debug) {
-    m_context = std::make_unique<EngineContext>();
-    m_context->windowWidth = windowWidth;
-    m_context->windowHeight = windowHeight;
-    m_context->renderDebugOutlines = debug;
+               bool debug)
+    : m_context() {
+    m_context.windowWidth = windowWidth;
+    m_context.windowHeight = windowHeight;
+    m_context.renderDebugOutlines = debug;
     m_renderer = std::make_shared<renderer::Renderer>(gameName, windowWidth,
                                                       windowHeight, debug);
     // Initialize the renderer right after creating it. Necessary in cases where
@@ -56,7 +56,7 @@ void Engine::StartGameLoop() {
     m_running = true;
 
     if (hasScene()) {
-        m_scene->OnStart(*m_context);
+        m_scene->OnStart(m_context);
     }
 
     std::vector<std::shared_ptr<renderer::IDrawable>> layers(2);
@@ -67,14 +67,14 @@ void Engine::StartGameLoop() {
         layers[0] = m_scene;
         layers[1] = m_displayLayout;
 
-        m_context->UpdateDelta();
+        m_context.UpdateDelta();
 
         quit = PollAndHandleEvent();
 
         if (hasScene()) {
-            m_scene->OnUpdate(*m_context);
+            m_scene->OnUpdate(m_context);
         }
 
-        m_renderer->Render(*m_context, layers);
+        m_renderer->Render(m_context, layers);
     }
 }

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -5,7 +5,7 @@ using namespace admirals::events;
 
 Engine::Engine(const std::string &gameName, int windowWidth, int windowHeight,
                bool debug) {
-    m_context = std::make_unique<Context>();
+    m_context = std::make_unique<EngineContext>();
     m_context->windowWidth = windowWidth;
     m_context->windowHeight = windowHeight;
     m_context->renderDebugOutlines = debug;

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -56,25 +56,36 @@ void Engine::StartGameLoop() {
     m_running = true;
 
     if (hasScene()) {
-        m_scene->OnStart(m_context);
+        m_scene->OnStart(GetContext());
     }
 
     std::vector<std::shared_ptr<renderer::IDrawable>> layers(2);
 
     // Start render loop
     bool quit = false;
+    std::chrono::time_point<std::chrono::high_resolution_clock> lastTime =
+        std::chrono::high_resolution_clock::now();
     while (!quit) {
         layers[0] = m_scene;
         layers[1] = m_displayLayout;
 
-        m_context.UpdateDelta();
+        std::chrono::time_point<std::chrono::high_resolution_clock> now =
+            std::chrono::high_resolution_clock::now();
+        m_context.deltaTime =
+            std::chrono::duration<double>(now - lastTime).count();
+        lastTime = now;
 
         quit = PollAndHandleEvent();
 
         if (hasScene()) {
-            m_scene->OnUpdate(m_context);
+            m_scene->OnUpdate(GetContext());
         }
 
-        m_renderer->Render(m_context, layers);
+        int windowWidth, windowHeight;
+        m_renderer->GetWindowSize(&windowWidth, &windowHeight);
+        m_context.windowWidth = windowWidth;
+        m_context.windowHeight = windowHeight;
+
+        m_renderer->Render(GetContext(), layers);
     }
 }

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -1,4 +1,5 @@
 #include "Engine.hpp"
+#include <chrono>
 
 using namespace admirals;
 using namespace admirals::events;
@@ -6,14 +7,14 @@ using namespace admirals::events;
 Engine::Engine(const std::string &gameName, int windowWidth, int windowHeight,
                bool debug)
     : m_context() {
-    m_context.windowWidth = windowWidth;
-    m_context.windowHeight = windowHeight;
+    m_context.windowSize = Vector2(static_cast<float>(windowWidth),
+                                   static_cast<float>(windowHeight));
     m_context.renderDebugOutlines = debug;
     m_renderer = std::make_shared<renderer::Renderer>(gameName, windowWidth,
-                                                      windowHeight, debug);
+                                                      windowHeight);
     // Initialize the renderer right after creating it. Necessary in cases where
     // DisplayLayout requires vk2d to be initialized.
-    m_renderer->Init(windowWidth, windowHeight, debug);
+    m_renderer->Init(m_context);
 
     m_displayLayout = std::make_shared<UI::DisplayLayout>();
 
@@ -69,8 +70,7 @@ void Engine::StartGameLoop() {
         layers[0] = m_scene;
         layers[1] = m_displayLayout;
 
-        std::chrono::time_point<std::chrono::high_resolution_clock> now =
-            std::chrono::high_resolution_clock::now();
+        const auto now = std::chrono::high_resolution_clock::now();
         m_context.deltaTime =
             std::chrono::duration<double>(now - lastTime).count();
         lastTime = now;
@@ -81,11 +81,7 @@ void Engine::StartGameLoop() {
             m_scene->OnUpdate(GetContext());
         }
 
-        int windowWidth, windowHeight;
-        m_renderer->GetWindowSize(&windowWidth, &windowHeight);
-        m_context.windowWidth = windowWidth;
-        m_context.windowHeight = windowHeight;
-
+        m_context.windowSize = m_renderer->GetWindowSize();
         m_renderer->Render(GetContext(), layers);
     }
 }

--- a/src/engine/Engine.hpp
+++ b/src/engine/Engine.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "Context.hpp"
 #include "GameObject.hpp"
 #include "Renderer.hpp"
 #include "Scene.hpp"
@@ -21,6 +22,8 @@ public:
     Engine(const std::string &gameName, int windowWidth, int windowHeight,
            bool debug);
 
+    inline Context &GetContext() const { return *m_context; }
+
     inline std::shared_ptr<UI::DisplayLayout>
     SetAndGetDisplayLayout(const std::shared_ptr<UI::DisplayLayout> &layout) {
         auto currentLayout = m_displayLayout;
@@ -38,7 +41,7 @@ public:
         m_scene = scene;
 
         if (hasScene() && !m_scene->IsInitialized()) {
-            m_scene->OnStart();
+            m_scene->OnStart(*m_context);
         }
 
         return currentScene;
@@ -58,7 +61,9 @@ public:
         }
     }
 
-    inline void ToggleDebugRendering() { m_renderer->ToggleDebugRendering(); }
+    inline void ToggleDebugRendering() {
+        m_context->renderDebugOutlines = !m_context->renderDebugOutlines;
+    }
 
     template <typename T, typename... _Args>
     inline std::shared_ptr<T> MakeUIElement(_Args &&..._args) {
@@ -78,8 +83,7 @@ public:
     inline void StopGameLoop() { m_running = false; }
 
     inline Vector2 GetWindowSize() {
-        auto rctx = m_renderer->Context();
-        return Vector2(rctx.windowWidth, rctx.windowHeight);
+        return Vector2(m_context->windowWidth, m_context->windowHeight);
     }
 
 private:
@@ -97,6 +101,7 @@ private:
     std::shared_ptr<scene::Scene> m_scene;
 
     std::shared_ptr<renderer::Renderer> m_renderer;
+    std::unique_ptr<Context> m_context;
 };
 
 } // namespace admirals

--- a/src/engine/Engine.hpp
+++ b/src/engine/Engine.hpp
@@ -22,7 +22,7 @@ public:
     Engine(const std::string &gameName, int windowWidth, int windowHeight,
            bool debug);
 
-    inline EngineContext &GetContext() const { return *m_context; }
+    inline EngineContext GetContext() const { return m_context; }
 
     inline std::shared_ptr<UI::DisplayLayout>
     SetAndGetDisplayLayout(const std::shared_ptr<UI::DisplayLayout> &layout) {
@@ -41,7 +41,7 @@ public:
         m_scene = scene;
 
         if (hasScene() && !m_scene->IsInitialized()) {
-            m_scene->OnStart(*m_context);
+            m_scene->OnStart(m_context);
         }
 
         return currentScene;
@@ -62,7 +62,7 @@ public:
     }
 
     inline void ToggleDebugRendering() {
-        m_context->renderDebugOutlines = !m_context->renderDebugOutlines;
+        m_context.renderDebugOutlines = !m_context.renderDebugOutlines;
     }
 
     template <typename T, typename... _Args>
@@ -83,7 +83,7 @@ public:
     inline void StopGameLoop() { m_running = false; }
 
     inline Vector2 GetWindowSize() {
-        return Vector2(m_context->windowWidth, m_context->windowHeight);
+        return Vector2(m_context.windowWidth, m_context.windowHeight);
     }
 
 private:
@@ -101,7 +101,7 @@ private:
     std::shared_ptr<scene::Scene> m_scene;
 
     std::shared_ptr<renderer::Renderer> m_renderer;
-    std::unique_ptr<EngineContext> m_context;
+    EngineContext m_context;
 };
 
 } // namespace admirals

--- a/src/engine/Engine.hpp
+++ b/src/engine/Engine.hpp
@@ -22,7 +22,7 @@ public:
     Engine(const std::string &gameName, int windowWidth, int windowHeight,
            bool debug);
 
-    inline EngineContext GetContext() const { return m_context; }
+    inline const EngineContext &GetContext() const { return m_context; }
 
     inline std::shared_ptr<UI::DisplayLayout>
     SetAndGetDisplayLayout(const std::shared_ptr<UI::DisplayLayout> &layout) {

--- a/src/engine/Engine.hpp
+++ b/src/engine/Engine.hpp
@@ -82,9 +82,7 @@ public:
     void StartGameLoop();
     inline void StopGameLoop() { m_running = false; }
 
-    inline Vector2 GetWindowSize() {
-        return Vector2(m_context.windowWidth, m_context.windowHeight);
-    }
+    inline Vector2 GetWindowSize() const { return m_context.windowSize; }
 
 private:
     bool PollAndHandleEvent();

--- a/src/engine/Engine.hpp
+++ b/src/engine/Engine.hpp
@@ -2,7 +2,7 @@
 
 #include <memory>
 
-#include "Context.hpp"
+#include "EngineContext.hpp"
 #include "GameObject.hpp"
 #include "Renderer.hpp"
 #include "Scene.hpp"
@@ -22,7 +22,7 @@ public:
     Engine(const std::string &gameName, int windowWidth, int windowHeight,
            bool debug);
 
-    inline Context &GetContext() const { return *m_context; }
+    inline EngineContext &GetContext() const { return *m_context; }
 
     inline std::shared_ptr<UI::DisplayLayout>
     SetAndGetDisplayLayout(const std::shared_ptr<UI::DisplayLayout> &layout) {
@@ -101,7 +101,7 @@ private:
     std::shared_ptr<scene::Scene> m_scene;
 
     std::shared_ptr<renderer::Renderer> m_renderer;
-    std::unique_ptr<Context> m_context;
+    std::unique_ptr<EngineContext> m_context;
 };
 
 } // namespace admirals

--- a/src/engine/EngineContext.hpp
+++ b/src/engine/EngineContext.hpp
@@ -8,7 +8,6 @@ public:
     EngineContext() : m_deltaTime(0.0) {
         m_lastTime = std::chrono::high_resolution_clock::now();
     }
-    EngineContext(const EngineContext &) = delete;
     ~EngineContext() {}
 
     void UpdateDelta() {

--- a/src/engine/EngineContext.hpp
+++ b/src/engine/EngineContext.hpp
@@ -3,30 +3,14 @@
 
 namespace admirals {
 
-class EngineContext {
-public:
-    EngineContext() : m_deltaTime(0.0) {
-        m_lastTime = std::chrono::high_resolution_clock::now();
-    }
-    ~EngineContext() {}
-
-    void UpdateDelta() {
-        std::chrono::time_point<std::chrono::high_resolution_clock> now =
-            std::chrono::high_resolution_clock::now();
-        m_deltaTime = std::chrono::duration<double>(now - m_lastTime).count();
-        m_lastTime = now;
-    }
-    inline double DeltaTime() const { return m_deltaTime; }
-
+struct EngineContext {
     int windowWidth;
     int windowHeight;
 
     // Indicates whether to draw outlines of elements for debugging purposes.
     bool renderDebugOutlines;
 
-private:
-    double m_deltaTime;
-    std::chrono::time_point<std::chrono::high_resolution_clock> m_lastTime;
+    double deltaTime;
 };
 
 } // namespace admirals

--- a/src/engine/EngineContext.hpp
+++ b/src/engine/EngineContext.hpp
@@ -3,13 +3,13 @@
 
 namespace admirals {
 
-class Context {
+class EngineContext {
 public:
-    Context() : m_deltaTime(0.0) {
+    EngineContext() : m_deltaTime(0.0) {
         m_lastTime = std::chrono::high_resolution_clock::now();
     }
-    Context(const Context &) = delete;
-    ~Context() {}
+    EngineContext(const EngineContext &) = delete;
+    ~EngineContext() {}
 
     void UpdateDelta() {
         std::chrono::time_point<std::chrono::high_resolution_clock> now =
@@ -17,7 +17,7 @@ public:
         m_deltaTime = std::chrono::duration<double>(now - m_lastTime).count();
         m_lastTime = now;
     }
-    double DeltaTime() const { return m_deltaTime; }
+    inline double DeltaTime() const { return m_deltaTime; }
 
     int windowWidth;
     int windowHeight;

--- a/src/engine/EngineContext.hpp
+++ b/src/engine/EngineContext.hpp
@@ -1,11 +1,10 @@
 #pragma once
-#include <chrono>
+#include "DataObjects.hpp"
 
 namespace admirals {
 
 struct EngineContext {
-    int windowWidth;
-    int windowHeight;
+    Vector2 windowSize;
 
     // Indicates whether to draw outlines of elements for debugging purposes.
     bool renderDebugOutlines;

--- a/src/engine/GameObject.hpp
+++ b/src/engine/GameObject.hpp
@@ -18,10 +18,10 @@ public:
     inline void SetPosition(const Vector2 &pos) { m_position = pos; }
     inline void SetPosition(float x, float y) { m_position = Vector2(x, y); }
 
-    virtual void OnStart(Context &c) = 0;
-    virtual void OnUpdate(Context &c) = 0;
+    virtual void OnStart(const EngineContext &c) = 0;
+    virtual void OnUpdate(const EngineContext &c) = 0;
 
-    virtual void Render(const Context &c) const = 0;
+    virtual void Render(const EngineContext &c) const = 0;
 
     template <typename T>
     static std::shared_ptr<GameObject>

--- a/src/engine/GameObject.hpp
+++ b/src/engine/GameObject.hpp
@@ -18,10 +18,10 @@ public:
     inline void SetPosition(const Vector2 &pos) { m_position = pos; }
     inline void SetPosition(float x, float y) { m_position = Vector2(x, y); }
 
-    virtual void OnStart() = 0;
-    virtual void OnUpdate() = 0;
+    virtual void OnStart(Context &c) = 0;
+    virtual void OnUpdate(Context &c) = 0;
 
-    virtual void Render(const renderer::RendererContext &r) const = 0;
+    virtual void Render(const Context &c) const = 0;
 
     template <typename T>
     static std::shared_ptr<GameObject>

--- a/src/engine/IDrawable.hpp
+++ b/src/engine/IDrawable.hpp
@@ -1,19 +1,11 @@
 #pragma once
-#include "Context.hpp"
+#include "EngineContext.hpp"
 
 namespace admirals::renderer {
 
-struct RendererContext {
-    int windowWidth;
-    int windowHeight;
-
-    // Indicates whether to draw outlines of elements for debugging purposes.
-    bool renderDebugOutlines;
-};
-
 class IDrawable {
 public:
-    virtual void Render(const Context &c) const = 0;
+    virtual void Render(const EngineContext &c) const = 0;
 };
 
 } // namespace admirals::renderer

--- a/src/engine/IDrawable.hpp
+++ b/src/engine/IDrawable.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "Context.hpp"
 
 namespace admirals::renderer {
 
@@ -12,7 +13,7 @@ struct RendererContext {
 
 class IDrawable {
 public:
-    virtual void Render(const RendererContext &r) const = 0;
+    virtual void Render(const Context &c) const = 0;
 };
 
 } // namespace admirals::renderer

--- a/src/engine/InteractiveDrawable.hpp
+++ b/src/engine/InteractiveDrawable.hpp
@@ -10,7 +10,7 @@ public:
     InteractiveDrawable(){};
     ~InteractiveDrawable(){};
 
-    virtual void Render(const renderer::RendererContext &r) const = 0;
+    virtual void Render(const Context &c) const = 0;
 
     virtual void HandleEvent(SDL_Event &e) = 0;
 };

--- a/src/engine/InteractiveDrawable.hpp
+++ b/src/engine/InteractiveDrawable.hpp
@@ -10,7 +10,7 @@ public:
     InteractiveDrawable(){};
     ~InteractiveDrawable(){};
 
-    virtual void Render(const Context &c) const = 0;
+    virtual void Render(const EngineContext &c) const = 0;
 
     virtual void HandleEvent(SDL_Event &e) = 0;
 };

--- a/src/engine/Renderer.cpp
+++ b/src/engine/Renderer.cpp
@@ -56,10 +56,13 @@ int Renderer::Init(int windowWidth, int windowHeight, bool debug) {
     return code;
 }
 
-void Renderer::Render(admirals::EngineContext &context,
+void Renderer::GetWindowSize(int *width, int *height) {
+    SDL_GetWindowSize(m_window, width, height);
+}
+
+void Renderer::Render(const admirals::EngineContext &context,
                       const DrawableCollection &drawables) {
     vk2dRendererStartFrame(Color::WHITE.Data());
-    SDL_GetWindowSize(m_window, &context.windowWidth, &context.windowHeight);
     for (const auto &drawable : drawables) {
         if (drawable == nullptr) {
             continue;

--- a/src/engine/Renderer.cpp
+++ b/src/engine/Renderer.cpp
@@ -56,7 +56,7 @@ int Renderer::Init(int windowWidth, int windowHeight, bool debug) {
     return code;
 }
 
-void Renderer::Render(admirals::Context &context,
+void Renderer::Render(admirals::EngineContext &context,
                       const DrawableCollection &drawables) {
     vk2dRendererStartFrame(Color::WHITE.Data());
     SDL_GetWindowSize(m_window, &context.windowWidth, &context.windowHeight);

--- a/src/engine/Renderer.cpp
+++ b/src/engine/Renderer.cpp
@@ -6,18 +6,20 @@
 #include "DataObjects.hpp"
 #include "Renderer.hpp"
 
+using namespace admirals;
 using namespace admirals::renderer;
 
-void RenderFont(const VK2DTexture font, const admirals::Vector2 &postion,
+void RenderFont(VK2DTexture font, const admirals::Vector2 &postion,
                 const char *text) {
     float x = postion.x();
     float y = postion.y();
-    float ox = x;
+    const float ox = x;
     for (int i = 0; i < (int)strlen(text); i++) {
         if (text[i] != '\n') {
-            vk2dRendererDrawTexture(font, x, y, 2, 2, 0, 0, 0,
-                                    (text[i] * 8) % 128,
-                                    floorf(text[i] / 16) * 16, 8, 16);
+            vk2dRendererDrawTexture(
+                font, x, y, 2.f, 2.f, 0.f, 0.f, 0.f,
+                static_cast<float>((text[i] * 8) % 128),
+                floorf(static_cast<float>(text[i]) / 16.f) * 16.f, 8.f, 16.f);
             x += 8 * 2;
         } else {
             x = ox;
@@ -26,8 +28,7 @@ void RenderFont(const VK2DTexture font, const admirals::Vector2 &postion,
     }
 }
 
-Renderer::Renderer(const std::string &name, int width, int height,
-                   bool debugRendering) {
+Renderer::Renderer(const std::string &name, int width, int height) {
     this->m_window = SDL_CreateWindow(name.c_str(), SDL_WINDOWPOS_CENTERED,
                                       SDL_WINDOWPOS_CENTERED, width, height,
                                       SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE);
@@ -38,29 +39,33 @@ Renderer::~Renderer() {
     SDL_DestroyWindow(this->m_window);
 }
 
-int Renderer::Init(int windowWidth, int windowHeight, bool debug) {
-    VK2DRendererConfig config = {VK2D_MSAA_32X, VK2D_SCREEN_MODE_IMMEDIATE,
-                                 VK2D_FILTER_TYPE_NEAREST};
-    VK2DStartupOptions options = {debug, debug, debug, "error.txt", false};
+int Renderer::Init(const EngineContext &c) {
+    const VK2DRendererConfig config = {
+        VK2D_MSAA_32X, VK2D_SCREEN_MODE_IMMEDIATE, VK2D_FILTER_TYPE_NEAREST};
+    VK2DStartupOptions options = {c.renderDebugOutlines, c.renderDebugOutlines,
+                                  c.renderDebugOutlines, "error.txt", false};
 
-    int code = vk2dRendererInit(this->m_window, config, &options);
+    const int code = vk2dRendererInit(this->m_window, config, &options);
     if (code < 0) {
         return code;
     }
 
-    VK2DCameraSpec camera = {
-        VK2D_CAMERA_TYPE_DEFAULT,         0, 0, static_cast<float>(windowWidth),
-        static_cast<float>(windowHeight), 1, 0};
+    const VK2DCameraSpec camera = {
+        VK2D_CAMERA_TYPE_DEFAULT, 0, 0, c.windowSize.x(),
+        c.windowSize.y(),         1, 0};
 
     vk2dRendererSetCamera(camera);
     return code;
 }
 
-void Renderer::GetWindowSize(int *width, int *height) {
-    SDL_GetWindowSize(m_window, width, height);
+Vector2 Renderer::GetWindowSize() const {
+    int width;
+    int height;
+    SDL_GetWindowSize(m_window, &width, &height);
+    return Vector2(static_cast<float>(width), static_cast<float>(height));
 }
 
-void Renderer::Render(const admirals::EngineContext &context,
+void Renderer::Render(const EngineContext &context,
                       const DrawableCollection &drawables) {
     vk2dRendererStartFrame(Color::WHITE.Data());
     for (const auto &drawable : drawables) {

--- a/src/engine/Renderer.cpp
+++ b/src/engine/Renderer.cpp
@@ -27,8 +27,7 @@ void RenderFont(const VK2DTexture font, const admirals::Vector2 &postion,
 }
 
 Renderer::Renderer(const std::string &name, int width, int height,
-                   bool debugRendering)
-    : m_context({width, height, debugRendering}) {
+                   bool debugRendering) {
     this->m_window = SDL_CreateWindow(name.c_str(), SDL_WINDOWPOS_CENTERED,
                                       SDL_WINDOWPOS_CENTERED, width, height,
                                       SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE);
@@ -39,7 +38,7 @@ Renderer::~Renderer() {
     SDL_DestroyWindow(this->m_window);
 }
 
-int Renderer::Init(bool debug) {
+int Renderer::Init(int windowWidth, int windowHeight, bool debug) {
     VK2DRendererConfig config = {VK2D_MSAA_32X, VK2D_SCREEN_MODE_IMMEDIATE,
                                  VK2D_FILTER_TYPE_NEAREST};
     VK2DStartupOptions options = {debug, debug, debug, "error.txt", false};
@@ -49,28 +48,24 @@ int Renderer::Init(bool debug) {
         return code;
     }
 
-    VK2DCameraSpec camera = {VK2D_CAMERA_TYPE_DEFAULT,
-                             0,
-                             0,
-                             static_cast<float>(m_context.windowWidth),
-                             static_cast<float>(m_context.windowHeight),
-                             1,
-                             0};
+    VK2DCameraSpec camera = {
+        VK2D_CAMERA_TYPE_DEFAULT,         0, 0, static_cast<float>(windowWidth),
+        static_cast<float>(windowHeight), 1, 0};
 
     vk2dRendererSetCamera(camera);
     return code;
 }
 
-void Renderer::Render(const DrawableCollection &drawables) {
+void Renderer::Render(admirals::Context &context,
+                      const DrawableCollection &drawables) {
     vk2dRendererStartFrame(Color::WHITE.Data());
-    SDL_GetWindowSize(m_window, &m_context.windowWidth,
-                      &m_context.windowHeight);
+    SDL_GetWindowSize(m_window, &context.windowWidth, &context.windowHeight);
     for (const auto &drawable : drawables) {
         if (drawable == nullptr) {
             continue;
         }
 
-        drawable->Render(m_context);
+        drawable->Render(context);
     }
     vk2dRendererEndFrame();
 }

--- a/src/engine/Renderer.hpp
+++ b/src/engine/Renderer.hpp
@@ -22,7 +22,10 @@ public:
     ~Renderer();
 
     int Init(int windowWidth, int windowHeight, bool debug);
-    void Render(EngineContext &context, const DrawableCollection &drawables);
+    void Render(const EngineContext &context,
+                const DrawableCollection &drawables);
+
+    void GetWindowSize(int *width, int *height);
 
     static void DrawLine(const Vector2 &p1, const Vector2 &p2,
                          const Color &color);

--- a/src/engine/Renderer.hpp
+++ b/src/engine/Renderer.hpp
@@ -24,10 +24,6 @@ public:
     int Init(int windowWidth, int windowHeight, bool debug);
     void Render(Context &context, const DrawableCollection &drawables);
 
-    // inline void ToggleDebugRendering() {
-    //     m_context.renderDebugOutlines = !m_context.renderDebugOutlines;
-    // }
-
     static void DrawLine(const Vector2 &p1, const Vector2 &p2,
                          const Color &color);
 
@@ -49,7 +45,6 @@ public:
                          const Color &color, const std::string &text);
 
 private:
-    // RendererContext m_context;
     SDL_Window *m_window;
 };
 

--- a/src/engine/Renderer.hpp
+++ b/src/engine/Renderer.hpp
@@ -7,6 +7,7 @@
 #include <SDL_video.h>
 #include <VK2D/Texture.h>
 
+#include "Context.hpp"
 #include "DataObjects.hpp"
 #include "IDrawable.hpp"
 
@@ -20,14 +21,12 @@ public:
              bool debugRendering);
     ~Renderer();
 
-    int Init(bool debug);
-    void Render(const DrawableCollection &drawables);
+    int Init(int windowWidth, int windowHeight, bool debug);
+    void Render(Context &context, const DrawableCollection &drawables);
 
-    inline void ToggleDebugRendering() {
-        m_context.renderDebugOutlines = !m_context.renderDebugOutlines;
-    }
-
-    inline RendererContext Context() const { return m_context; }
+    // inline void ToggleDebugRendering() {
+    //     m_context.renderDebugOutlines = !m_context.renderDebugOutlines;
+    // }
 
     static void DrawLine(const Vector2 &p1, const Vector2 &p2,
                          const Color &color);
@@ -50,7 +49,7 @@ public:
                          const Color &color, const std::string &text);
 
 private:
-    RendererContext m_context;
+    // RendererContext m_context;
     SDL_Window *m_window;
 };
 

--- a/src/engine/Renderer.hpp
+++ b/src/engine/Renderer.hpp
@@ -7,7 +7,7 @@
 #include <SDL_video.h>
 #include <VK2D/Texture.h>
 
-#include "Context.hpp"
+#include "EngineContext.hpp"
 #include "DataObjects.hpp"
 #include "IDrawable.hpp"
 
@@ -22,7 +22,7 @@ public:
     ~Renderer();
 
     int Init(int windowWidth, int windowHeight, bool debug);
-    void Render(Context &context, const DrawableCollection &drawables);
+    void Render(EngineContext &context, const DrawableCollection &drawables);
 
     static void DrawLine(const Vector2 &p1, const Vector2 &p2,
                          const Color &color);

--- a/src/engine/Renderer.hpp
+++ b/src/engine/Renderer.hpp
@@ -7,8 +7,8 @@
 #include <SDL_video.h>
 #include <VK2D/Texture.h>
 
-#include "EngineContext.hpp"
 #include "DataObjects.hpp"
+#include "EngineContext.hpp"
 #include "IDrawable.hpp"
 
 namespace admirals::renderer {

--- a/src/engine/Renderer.hpp
+++ b/src/engine/Renderer.hpp
@@ -17,15 +17,14 @@ typedef std::vector<std::shared_ptr<IDrawable>> DrawableCollection;
 
 class Renderer {
 public:
-    Renderer(const std::string &name, int width, int height,
-             bool debugRendering);
+    Renderer(const std::string &name, int width, int height);
     ~Renderer();
 
-    int Init(int windowWidth, int windowHeight, bool debug);
-    void Render(const EngineContext &context,
-                const DrawableCollection &drawables);
+    int Init(const EngineContext &context);
+    static void Render(const EngineContext &context,
+                       const DrawableCollection &drawables);
 
-    void GetWindowSize(int *width, int *height);
+    Vector2 GetWindowSize() const;
 
     static void DrawLine(const Vector2 &p1, const Vector2 &p2,
                          const Color &color);

--- a/src/engine/Scene.cpp
+++ b/src/engine/Scene.cpp
@@ -7,7 +7,7 @@ void Scene::AddObject(std::shared_ptr<GameObject> object) {
     this->m_objects.Insert(std::move(object));
 }
 
-void Scene::Render(const Context &c) const {
+void Scene::Render(const EngineContext &c) const {
     for (const auto &object : this->m_objects) {
         object->Render(c);
     }
@@ -53,7 +53,7 @@ std::vector<std::string> Scene::GetSceneObjectNames() {
     return vec;
 }
 
-void Scene::OnStart(Context &c) {
+void Scene::OnStart(const EngineContext &c) {
     m_isInitialized = true;
 
     for (const auto &object : this->m_objects) {
@@ -61,7 +61,7 @@ void Scene::OnStart(Context &c) {
     }
 }
 
-void Scene::OnUpdate(Context &c) {
+void Scene::OnUpdate(const EngineContext &c) {
     for (const auto &object : this->m_objects) {
         object->OnUpdate(c);
     }

--- a/src/engine/Scene.cpp
+++ b/src/engine/Scene.cpp
@@ -7,9 +7,9 @@ void Scene::AddObject(std::shared_ptr<GameObject> object) {
     this->m_objects.Insert(std::move(object));
 }
 
-void Scene::Render(const renderer::RendererContext &r) const {
+void Scene::Render(const Context &c) const {
     for (const auto &object : this->m_objects) {
-        object->Render(r);
+        object->Render(c);
     }
 }
 
@@ -53,16 +53,16 @@ std::vector<std::string> Scene::GetSceneObjectNames() {
     return vec;
 }
 
-void Scene::OnStart() {
+void Scene::OnStart(Context &c) {
     m_isInitialized = true;
 
     for (const auto &object : this->m_objects) {
-        object->OnStart();
+        object->OnStart(c);
     }
 }
 
-void Scene::OnUpdate() {
+void Scene::OnUpdate(Context &c) {
     for (const auto &object : this->m_objects) {
-        object->OnUpdate();
+        object->OnUpdate(c);
     }
 }

--- a/src/engine/Scene.hpp
+++ b/src/engine/Scene.hpp
@@ -17,12 +17,12 @@ public:
     void RemoveObject(const std::string &key);
     bool ExistObject(std::shared_ptr<GameObject> object);
     bool ExistObject(const std::string &key);
-    void Render(const renderer::RendererContext &r) const override;
+    void Render(const Context &c) const override;
     int NumObjectsInScene();
 
     std::vector<std::string> GetSceneObjectNames();
-    void OnStart();
-    void OnUpdate();
+    void OnStart(Context &c);
+    void OnUpdate(Context &c);
 
     bool IsInitialized() const { return m_isInitialized; }
 

--- a/src/engine/Scene.hpp
+++ b/src/engine/Scene.hpp
@@ -17,12 +17,12 @@ public:
     void RemoveObject(const std::string &key);
     bool ExistObject(std::shared_ptr<GameObject> object);
     bool ExistObject(const std::string &key);
-    void Render(const Context &c) const override;
+    void Render(const EngineContext &c) const override;
     int NumObjectsInScene();
 
     std::vector<std::string> GetSceneObjectNames();
-    void OnStart(Context &c);
-    void OnUpdate(Context &c);
+    void OnStart(const EngineContext &c);
+    void OnUpdate(const EngineContext &c);
 
     bool IsInitialized() const { return m_isInitialized; }
 

--- a/src/engine/UI/DisplayLayout.cpp
+++ b/src/engine/UI/DisplayLayout.cpp
@@ -23,20 +23,20 @@ Vector2 DisplayLayout::GetOriginFromDisplayPosition(DisplayPosition pos,
 
     // Handle center.
     if (pos == DisplayPosition::Center) {
-        origin[0] = (static_cast<float>(c.windowWidth) - displaySize[0]) / 2.0f;
+        origin[0] = (c.windowSize.x() - displaySize[0]) / 2.0f;
         return origin;
     }
 
     // Fix right offset.
     if (pos == DisplayPosition::UpperRight ||
         pos == DisplayPosition::LowerRight) {
-        origin[0] = static_cast<float>(c.windowWidth) - displaySize[0];
+        origin[0] = c.windowSize.x() - displaySize[0];
     }
 
     // Fix lower offset.
     if (pos == DisplayPosition::LowerLeft ||
         pos == DisplayPosition::LowerRight) {
-        origin[1] = static_cast<float>(c.windowHeight) - displaySize[1];
+        origin[1] = c.windowSize.y() - displaySize[1];
     }
 
     return origin;

--- a/src/engine/UI/DisplayLayout.cpp
+++ b/src/engine/UI/DisplayLayout.cpp
@@ -18,7 +18,7 @@ void DisplayLayout::AddElement(std::shared_ptr<Element> element) {
 
 Vector2 DisplayLayout::GetOriginFromDisplayPosition(DisplayPosition pos,
                                                     const Vector2 &displaySize,
-                                                    const Context &c) {
+                                                    const EngineContext &c) {
     Vector2 origin(0, 0);
 
     // Handle center.
@@ -42,7 +42,7 @@ Vector2 DisplayLayout::GetOriginFromDisplayPosition(DisplayPosition pos,
     return origin;
 }
 
-void DisplayLayout::Render(const Context &c) const {
+void DisplayLayout::Render(const EngineContext &c) const {
     Vector4 positionOffsets = Vector4(0);
 
     for (const auto &element : m_elements) {

--- a/src/engine/UI/DisplayLayout.cpp
+++ b/src/engine/UI/DisplayLayout.cpp
@@ -16,33 +16,33 @@ void DisplayLayout::AddElement(std::shared_ptr<Element> element) {
     this->m_elements.Insert(std::move(element));
 }
 
-Vector2 DisplayLayout::GetOriginFromDisplayPosition(
-    DisplayPosition pos, const Vector2 &displaySize,
-    const renderer::RendererContext &r) {
+Vector2 DisplayLayout::GetOriginFromDisplayPosition(DisplayPosition pos,
+                                                    const Vector2 &displaySize,
+                                                    const Context &c) {
     Vector2 origin(0, 0);
 
     // Handle center.
     if (pos == DisplayPosition::Center) {
-        origin[0] = (static_cast<float>(r.windowWidth) - displaySize[0]) / 2.0f;
+        origin[0] = (static_cast<float>(c.windowWidth) - displaySize[0]) / 2.0f;
         return origin;
     }
 
     // Fix right offset.
     if (pos == DisplayPosition::UpperRight ||
         pos == DisplayPosition::LowerRight) {
-        origin[0] = static_cast<float>(r.windowWidth) - displaySize[0];
+        origin[0] = static_cast<float>(c.windowWidth) - displaySize[0];
     }
 
     // Fix lower offset.
     if (pos == DisplayPosition::LowerLeft ||
         pos == DisplayPosition::LowerRight) {
-        origin[1] = static_cast<float>(r.windowHeight) - displaySize[1];
+        origin[1] = static_cast<float>(c.windowHeight) - displaySize[1];
     }
 
     return origin;
 }
 
-void DisplayLayout::Render(const renderer::RendererContext &r) const {
+void DisplayLayout::Render(const Context &c) const {
     Vector4 positionOffsets = Vector4(0);
 
     for (const auto &element : m_elements) {
@@ -50,7 +50,7 @@ void DisplayLayout::Render(const renderer::RendererContext &r) const {
         Vector2 displaySize = element->GetDisplaySize();
 
         // Calculate the origin with respect to the matching positionOffset.
-        Vector2 origin = GetOriginFromDisplayPosition(pos, displaySize, r);
+        Vector2 origin = GetOriginFromDisplayPosition(pos, displaySize, c);
         origin[0] += positionOffsets[pos];
 
         element->SetDisplayOrigin(origin);
@@ -58,7 +58,7 @@ void DisplayLayout::Render(const renderer::RendererContext &r) const {
         element->Render(this->m_font);
 
         // If debugging, render an outline around the UI Element.
-        if (r.renderDebugOutlines) {
+        if (c.renderDebugOutlines) {
             renderer::Renderer::DrawRectangleOutline(origin, displaySize, 2,
                                                      Color::RED);
         }

--- a/src/engine/UI/DisplayLayout.hpp
+++ b/src/engine/UI/DisplayLayout.hpp
@@ -13,15 +13,14 @@ class DisplayLayout : public InteractiveDrawable {
 public:
     DisplayLayout();
 
-    void Render(const renderer::RendererContext &r) const override;
+    void Render(const Context &c) const override;
     void HandleEvent(SDL_Event &e) override;
 
     void AddElement(std::shared_ptr<Element> element);
 
-    static Vector2
-    GetOriginFromDisplayPosition(DisplayPosition pos,
-                                 const Vector2 &displaySize,
-                                 const renderer::RendererContext &r);
+    static Vector2 GetOriginFromDisplayPosition(DisplayPosition pos,
+                                                const Vector2 &displaySize,
+                                                const Context &c);
 
     inline Vector2 TextFontSize(const std::string &text) const {
         return Vector2(static_cast<float>(text.length()) * m_fontWidth,

--- a/src/engine/UI/DisplayLayout.hpp
+++ b/src/engine/UI/DisplayLayout.hpp
@@ -13,14 +13,14 @@ class DisplayLayout : public InteractiveDrawable {
 public:
     DisplayLayout();
 
-    void Render(const Context &c) const override;
+    void Render(const EngineContext &c) const override;
     void HandleEvent(SDL_Event &e) override;
 
     void AddElement(std::shared_ptr<Element> element);
 
     static Vector2 GetOriginFromDisplayPosition(DisplayPosition pos,
                                                 const Vector2 &displaySize,
-                                                const Context &c);
+                                                const EngineContext &c);
 
     inline Vector2 TextFontSize(const std::string &text) const {
         return Vector2(static_cast<float>(text.length()) * m_fontWidth,

--- a/src/engine/UI/menu/Menu.cpp
+++ b/src/engine/UI/menu/Menu.cpp
@@ -21,15 +21,15 @@ void Menu::AddMenuOption(const std::shared_ptr<MenuOption> &menuOption) {
     this->AddElement(static_cast<std::shared_ptr<Element>>(menuOption));
 }
 
-void Menu::Render(const renderer::RendererContext &r) const {
+void Menu::Render(const Context &c) const {
 
     float centerPositionOffset = m_topPadding;
 
     // Draw background.
     renderer::Renderer::DrawRectangle(
         Vector2(0, 0),
-        Vector2(static_cast<float>(r.windowWidth),
-                static_cast<float>(r.windowHeight)),
+        Vector2(static_cast<float>(c.windowWidth),
+                static_cast<float>(c.windowHeight)),
         m_bgColor);
 
     for (auto it = m_elements.rbegin(); it != m_elements.rend(); ++it) {
@@ -40,7 +40,7 @@ void Menu::Render(const renderer::RendererContext &r) const {
 
         // Calculate the origin with respect to the matching positionOffset.
         Vector2 origin =
-            DisplayLayout::GetOriginFromDisplayPosition(pos, displaySize, r);
+            DisplayLayout::GetOriginFromDisplayPosition(pos, displaySize, c);
         origin[1] += centerPositionOffset;
 
         // Update menu-dependent state of the options.
@@ -60,7 +60,7 @@ void Menu::Render(const renderer::RendererContext &r) const {
         }
 
         // If debugging, render an outline around the UI Element.
-        if (r.renderDebugOutlines) {
+        if (c.renderDebugOutlines) {
             renderer::Renderer::DrawRectangleOutline(origin, displaySize, 2,
                                                      Color::RED);
         }

--- a/src/engine/UI/menu/Menu.cpp
+++ b/src/engine/UI/menu/Menu.cpp
@@ -26,11 +26,7 @@ void Menu::Render(const EngineContext &c) const {
     float centerPositionOffset = m_topPadding;
 
     // Draw background.
-    renderer::Renderer::DrawRectangle(
-        Vector2(0, 0),
-        Vector2(static_cast<float>(c.windowWidth),
-                static_cast<float>(c.windowHeight)),
-        m_bgColor);
+    renderer::Renderer::DrawRectangle(Vector2(0, 0), c.windowSize, m_bgColor);
 
     for (auto it = m_elements.rbegin(); it != m_elements.rend(); ++it) {
         auto option = std::dynamic_pointer_cast<MenuOption>(*it);

--- a/src/engine/UI/menu/Menu.cpp
+++ b/src/engine/UI/menu/Menu.cpp
@@ -21,7 +21,7 @@ void Menu::AddMenuOption(const std::shared_ptr<MenuOption> &menuOption) {
     this->AddElement(static_cast<std::shared_ptr<Element>>(menuOption));
 }
 
-void Menu::Render(const Context &c) const {
+void Menu::Render(const EngineContext &c) const {
 
     float centerPositionOffset = m_topPadding;
 

--- a/src/engine/UI/menu/Menu.hpp
+++ b/src/engine/UI/menu/Menu.hpp
@@ -15,7 +15,7 @@ public:
 
     void AddMenuOption(const std::shared_ptr<MenuOption> &menuOption);
 
-    void Render(const renderer::RendererContext &r) const override;
+    void Render(const Context &c) const override;
 
     inline void SetTextColor(const Color &color) { m_fgColor = color; }
 

--- a/src/engine/UI/menu/Menu.hpp
+++ b/src/engine/UI/menu/Menu.hpp
@@ -15,7 +15,7 @@ public:
 
     void AddMenuOption(const std::shared_ptr<MenuOption> &menuOption);
 
-    void Render(const Context &c) const override;
+    void Render(const EngineContext &c) const override;
 
     inline void SetTextColor(const Color &color) { m_fgColor = color; }
 

--- a/src/mvp/objects/Background.cpp
+++ b/src/mvp/objects/Background.cpp
@@ -8,12 +8,12 @@ using namespace admirals::mvp::objects;
 Background::Background(const std::string &name, const Color &color)
     : scene::GameObject(name, 0, Vector2(0)), m_color(color) {}
 
-void Background::OnStart() {}
+void Background::OnStart(Context &c) {}
 
-void Background::OnUpdate() {}
+void Background::OnUpdate(Context &c) {}
 
-void Background::Render(const renderer::RendererContext &r) const {
-    const Vector2 size = Vector2(static_cast<float>(r.windowWidth),
-                                 static_cast<float>(r.windowHeight));
+void Background::Render(const Context &c) const {
+    const Vector2 size = Vector2(static_cast<float>(c.windowWidth),
+                                 static_cast<float>(c.windowHeight));
     renderer::Renderer::DrawRectangle(Vector2(0, 0), size, m_color);
 }

--- a/src/mvp/objects/Background.cpp
+++ b/src/mvp/objects/Background.cpp
@@ -13,7 +13,5 @@ void Background::OnStart(const EngineContext &c) {}
 void Background::OnUpdate(const EngineContext &c) {}
 
 void Background::Render(const EngineContext &c) const {
-    const Vector2 size = Vector2(static_cast<float>(c.windowWidth),
-                                 static_cast<float>(c.windowHeight));
-    renderer::Renderer::DrawRectangle(Vector2(0, 0), size, m_color);
+    renderer::Renderer::DrawRectangle(Vector2(0, 0), c.windowSize, m_color);
 }

--- a/src/mvp/objects/Background.cpp
+++ b/src/mvp/objects/Background.cpp
@@ -8,11 +8,11 @@ using namespace admirals::mvp::objects;
 Background::Background(const std::string &name, const Color &color)
     : scene::GameObject(name, 0, Vector2(0)), m_color(color) {}
 
-void Background::OnStart(Context &c) {}
+void Background::OnStart(const EngineContext &c) {}
 
-void Background::OnUpdate(Context &c) {}
+void Background::OnUpdate(const EngineContext &c) {}
 
-void Background::Render(const Context &c) const {
+void Background::Render(const EngineContext &c) const {
     const Vector2 size = Vector2(static_cast<float>(c.windowWidth),
                                  static_cast<float>(c.windowHeight));
     renderer::Renderer::DrawRectangle(Vector2(0, 0), size, m_color);

--- a/src/mvp/objects/Background.hpp
+++ b/src/mvp/objects/Background.hpp
@@ -7,9 +7,9 @@ class Background : public scene::GameObject {
 public:
     Background(const std::string &name, const Color &color);
 
-    void OnStart(Context &c) override;
-    void OnUpdate(Context &c) override;
-    void Render(const Context &c) const override;
+    void OnStart(const EngineContext &c) override;
+    void OnUpdate(const EngineContext &c) override;
+    void Render(const EngineContext &c) const override;
 
 private:
     Color m_color;

--- a/src/mvp/objects/Background.hpp
+++ b/src/mvp/objects/Background.hpp
@@ -7,9 +7,9 @@ class Background : public scene::GameObject {
 public:
     Background(const std::string &name, const Color &color);
 
-    void OnStart() override;
-    void OnUpdate() override;
-    void Render(const renderer::RendererContext &r) const override;
+    void OnStart(Context &c) override;
+    void OnUpdate(Context &c) override;
+    void Render(const Context &c) const override;
 
 private:
     Color m_color;

--- a/src/mvp/objects/GameManager.cpp
+++ b/src/mvp/objects/GameManager.cpp
@@ -12,9 +12,9 @@ GameManager::GameManager(const std::string &name)
 
 GameManager::~GameManager() {}
 
-void GameManager::OnStart(Context &c) { srand(time(NULL)); }
+void GameManager::OnStart(const EngineContext &c) { srand(time(NULL)); }
 
-void GameManager::OnUpdate(Context &c) {
+void GameManager::OnUpdate(const EngineContext &c) {
     if (!m_gameStarted) {
         return;
     }

--- a/src/mvp/objects/GameManager.cpp
+++ b/src/mvp/objects/GameManager.cpp
@@ -12,9 +12,9 @@ GameManager::GameManager(const std::string &name)
 
 GameManager::~GameManager() {}
 
-void GameManager::OnStart() { srand(time(NULL)); }
+void GameManager::OnStart(Context &c) { srand(time(NULL)); }
 
-void GameManager::OnUpdate() {
+void GameManager::OnUpdate(Context &c) {
     if (!m_gameStarted) {
         return;
     }

--- a/src/mvp/objects/GameManager.hpp
+++ b/src/mvp/objects/GameManager.hpp
@@ -22,9 +22,9 @@ public:
 
     events::EventSystem<CoinsChangesEventArgs> onCoinsChanged;
 
-    void OnStart(Context &c) override;
-    void OnUpdate(Context &c) override;
-    void Render(const Context &c) const override {}
+    void OnStart(const EngineContext &c) override;
+    void OnUpdate(const EngineContext &c) override;
+    void Render(const EngineContext &c) const override {}
 
     void StartGame() { m_gameStarted = true; }
     void StopGame();

--- a/src/mvp/objects/GameManager.hpp
+++ b/src/mvp/objects/GameManager.hpp
@@ -22,9 +22,9 @@ public:
 
     events::EventSystem<CoinsChangesEventArgs> onCoinsChanged;
 
-    void OnStart() override;
-    void OnUpdate() override;
-    void Render(const renderer::RendererContext &r) const override {}
+    void OnStart(Context &c) override;
+    void OnUpdate(Context &c) override;
+    void Render(const Context &c) const override {}
 
     void StartGame() { m_gameStarted = true; }
     void StopGame();

--- a/src/mvp/objects/Grid.cpp
+++ b/src/mvp/objects/Grid.cpp
@@ -13,17 +13,15 @@ void Grid::OnStart(const EngineContext &c) {}
 void Grid::OnUpdate(const EngineContext &c) {}
 
 void Grid::Render(const EngineContext &c) const {
-    Vector2 offset = Vector2(c.windowWidth - GameData::GridSize,
-                             c.windowHeight - GameData::GridSize) /
-                     2;
+    const Vector2 offset = (c.windowSize - Vector2(GameData::GridSize)) / 2.f;
     for (int i = 0; i <= GameData::GridCells; i++) {
-        float x = i * GameData::CellSize;
+        const float x = static_cast<float>(i) * GameData::CellSize;
         renderer::Renderer::DrawLine(Vector2(x, 0) + offset,
                                      Vector2(x, GameData::GridSize) + offset,
                                      m_color);
     }
     for (int i = 0; i <= GameData::GridCells; i++) {
-        float y = i * GameData::CellSize;
+        const float y = static_cast<float>(i) * GameData::CellSize;
         renderer::Renderer::DrawLine(Vector2(0, y) + offset,
                                      Vector2(GameData::GridSize, y) + offset,
                                      m_color);

--- a/src/mvp/objects/Grid.cpp
+++ b/src/mvp/objects/Grid.cpp
@@ -8,13 +8,13 @@ using namespace admirals::mvp::objects;
 Grid::Grid(const std::string &name, const Color &color)
     : scene::GameObject(name, 1000, Vector2(0, 0)), m_color(color) {}
 
-void Grid::OnStart() {}
+void Grid::OnStart(Context &c) {}
 
-void Grid::OnUpdate() {}
+void Grid::OnUpdate(Context &c) {}
 
-void Grid::Render(const renderer::RendererContext &r) const {
-    Vector2 offset = Vector2(r.windowWidth - GameData::GridSize,
-                             r.windowHeight - GameData::GridSize) /
+void Grid::Render(const Context &c) const {
+    Vector2 offset = Vector2(c.windowWidth - GameData::GridSize,
+                             c.windowHeight - GameData::GridSize) /
                      2;
     for (int i = 0; i <= GameData::GridCells; i++) {
         float x = i * GameData::CellSize;

--- a/src/mvp/objects/Grid.cpp
+++ b/src/mvp/objects/Grid.cpp
@@ -8,11 +8,11 @@ using namespace admirals::mvp::objects;
 Grid::Grid(const std::string &name, const Color &color)
     : scene::GameObject(name, 1000, Vector2(0, 0)), m_color(color) {}
 
-void Grid::OnStart(Context &c) {}
+void Grid::OnStart(const EngineContext &c) {}
 
-void Grid::OnUpdate(Context &c) {}
+void Grid::OnUpdate(const EngineContext &c) {}
 
-void Grid::Render(const Context &c) const {
+void Grid::Render(const EngineContext &c) const {
     Vector2 offset = Vector2(c.windowWidth - GameData::GridSize,
                              c.windowHeight - GameData::GridSize) /
                      2;

--- a/src/mvp/objects/Grid.hpp
+++ b/src/mvp/objects/Grid.hpp
@@ -7,9 +7,9 @@ class Grid : public scene::GameObject {
 public:
     Grid(const std::string &name, const Color &color);
 
-    void OnStart(Context &c) override;
-    void OnUpdate(Context &c) override;
-    void Render(const Context &c) const override;
+    void OnStart(const EngineContext &c) override;
+    void OnUpdate(const EngineContext &c) override;
+    void Render(const EngineContext &c) const override;
 
 private:
     Color m_color;

--- a/src/mvp/objects/Grid.hpp
+++ b/src/mvp/objects/Grid.hpp
@@ -7,9 +7,9 @@ class Grid : public scene::GameObject {
 public:
     Grid(const std::string &name, const Color &color);
 
-    void OnStart() override;
-    void OnUpdate() override;
-    void Render(const renderer::RendererContext &r) const override;
+    void OnStart(Context &c) override;
+    void OnUpdate(Context &c) override;
+    void Render(const Context &c) const override;
 
 private:
     Color m_color;

--- a/src/mvp/objects/MenuMovingShip.hpp
+++ b/src/mvp/objects/MenuMovingShip.hpp
@@ -25,7 +25,7 @@ public:
         Vector2 position = this->GetPosition();
         Vector2 windowSize = GameData::engine->GetWindowSize();
 
-        float newX = position.x() + m_shipSpeed * c.DeltaTime();
+        float newX = position.x() + m_shipSpeed * c.deltaTime;
         if (newX > windowSize[0]) {
             newX = -m_size.x();
         }

--- a/src/mvp/objects/MenuMovingShip.hpp
+++ b/src/mvp/objects/MenuMovingShip.hpp
@@ -17,11 +17,11 @@ public:
                  Ship::ShipTypeToTexOffset(type)),
           m_size(size), m_shipSpeed(shipSpeed) {}
 
-    void OnStart(Context &c) override {
+    void OnStart(const EngineContext &c) override {
         m_time = std::chrono::high_resolution_clock::now();
     }
 
-    void OnUpdate(Context &c) override {
+    void OnUpdate(const EngineContext &c) override {
         Vector2 position = this->GetPosition();
         Vector2 windowSize = GameData::engine->GetWindowSize();
 

--- a/src/mvp/objects/MenuMovingShip.hpp
+++ b/src/mvp/objects/MenuMovingShip.hpp
@@ -6,8 +6,6 @@
 #include "Sprite.hpp"
 #include "commontypes.hpp"
 
-static const float SECONDS_PER_MICROSECOND = 1000000.0f;
-
 namespace admirals::mvp::objects {
 
 class MenuMovingShip : public Sprite {
@@ -19,28 +17,21 @@ public:
                  Ship::ShipTypeToTexOffset(type)),
           m_size(size), m_shipSpeed(shipSpeed) {}
 
-    void OnStart() override {
+    void OnStart(Context &c) override {
         m_time = std::chrono::high_resolution_clock::now();
     }
 
-    void OnUpdate() override {
-        auto time = std::chrono::high_resolution_clock::now();
-        float deltaTime =
-            std::chrono::duration_cast<std::chrono::microseconds>(time - m_time)
-                .count() /
-            SECONDS_PER_MICROSECOND;
-
+    void OnUpdate(Context &c) override {
         Vector2 position = this->GetPosition();
         Vector2 windowSize = GameData::engine->GetWindowSize();
 
-        float newX = position.x() + m_shipSpeed * deltaTime;
+        float newX = position.x() + m_shipSpeed * c.DeltaTime();
         if (newX > windowSize[0]) {
             newX = -m_size.x();
         }
 
         position.SetX(newX);
         this->SetPosition(position);
-        m_time = time;
     }
 
 private:

--- a/src/mvp/objects/NetworkManager.cpp
+++ b/src/mvp/objects/NetworkManager.cpp
@@ -11,7 +11,7 @@ NetworkManager::NetworkManager(const std::string &name,
 
 NetworkManager::~NetworkManager() {}
 
-void NetworkManager::OnStart(Context &c) {
+void NetworkManager::OnStart(const EngineContext &c) {
     printf("NetworkManager::OnStart()\n");
 
     // Should probably be called later and not here
@@ -26,7 +26,7 @@ void NetworkManager::OnStart(Context &c) {
     ReadyUp();
 }
 
-void NetworkManager::OnUpdate(Context &c) { HandleMessages(); }
+void NetworkManager::OnUpdate(const EngineContext &c) { HandleMessages(); }
 
 void NetworkManager::BuyShip(uint8_t type) {
     if (m_debug)

--- a/src/mvp/objects/NetworkManager.cpp
+++ b/src/mvp/objects/NetworkManager.cpp
@@ -11,7 +11,7 @@ NetworkManager::NetworkManager(const std::string &name,
 
 NetworkManager::~NetworkManager() {}
 
-void NetworkManager::OnStart() {
+void NetworkManager::OnStart(Context &c) {
     printf("NetworkManager::OnStart()\n");
 
     // Should probably be called later and not here
@@ -26,7 +26,7 @@ void NetworkManager::OnStart() {
     ReadyUp();
 }
 
-void NetworkManager::OnUpdate() { HandleMessages(); }
+void NetworkManager::OnUpdate(Context &c) { HandleMessages(); }
 
 void NetworkManager::BuyShip(uint8_t type) {
     if (m_debug)

--- a/src/mvp/objects/NetworkManager.hpp
+++ b/src/mvp/objects/NetworkManager.hpp
@@ -14,9 +14,9 @@ public:
     NetworkManager(const std::string &name, GameManager &gameManager);
     ~NetworkManager();
 
-    void OnStart(Context &c) override;
-    void OnUpdate(Context &c) override;
-    void Render(const Context &c) const override {}
+    void OnStart(const EngineContext &c) override;
+    void OnUpdate(const EngineContext &c) override;
+    void Render(const EngineContext &c) const override {}
 
     void BuyShip(uint8_t type);
     void MoveShip(uint16_t id, uint8_t x, uint8_t y);

--- a/src/mvp/objects/NetworkManager.hpp
+++ b/src/mvp/objects/NetworkManager.hpp
@@ -14,9 +14,9 @@ public:
     NetworkManager(const std::string &name, GameManager &gameManager);
     ~NetworkManager();
 
-    void OnStart() override;
-    void OnUpdate() override;
-    void Render(const renderer::RendererContext &r) const override {}
+    void OnStart(Context &c) override;
+    void OnUpdate(Context &c) override;
+    void Render(const Context &c) const override {}
 
     void BuyShip(uint8_t type);
     void MoveShip(uint16_t id, uint8_t x, uint8_t y);

--- a/src/mvp/objects/Quad.cpp
+++ b/src/mvp/objects/Quad.cpp
@@ -14,10 +14,10 @@ void Quad::OnUpdate(const EngineContext &c) {}
 void Quad::OnStart(const EngineContext &c) {}
 
 void Quad::Render(const EngineContext &c) const {
-    Vector2 pos = this->GetPosition();
-    Vector2 offset =
-        Vector2(c.windowWidth - GameData::GridSize,
-                c.windowHeight - GameData::GridSize - 2 * GameData::CellSize) /
-        2;
+    const Vector2 pos = this->GetPosition();
+    const Vector2 offset =
+        (c.windowSize - Vector2(GameData::GridSize,
+                                GameData::GridSize + 2 * GameData::CellSize)) /
+        2.f;
     renderer::Renderer::DrawRectangle(pos + offset, m_size, m_color);
 }

--- a/src/mvp/objects/Quad.cpp
+++ b/src/mvp/objects/Quad.cpp
@@ -9,15 +9,15 @@ Quad::Quad(const std::string &name, const Vector3 &position,
            const Vector2 &size, const Color &color)
     : scene::GameObject(name, position), m_size(size), m_color(color) {}
 
-void Quad::OnUpdate() {}
+void Quad::OnUpdate(Context &c) {}
 
-void Quad::OnStart() {}
+void Quad::OnStart(Context &c) {}
 
-void Quad::Render(const renderer::RendererContext &r) const {
+void Quad::Render(const Context &c) const {
     Vector2 pos = this->GetPosition();
     Vector2 offset =
-        Vector2(r.windowWidth - GameData::GridSize,
-                r.windowHeight - GameData::GridSize - 2 * GameData::CellSize) /
+        Vector2(c.windowWidth - GameData::GridSize,
+                c.windowHeight - GameData::GridSize - 2 * GameData::CellSize) /
         2;
     renderer::Renderer::DrawRectangle(pos + offset, m_size, m_color);
 }

--- a/src/mvp/objects/Quad.cpp
+++ b/src/mvp/objects/Quad.cpp
@@ -9,11 +9,11 @@ Quad::Quad(const std::string &name, const Vector3 &position,
            const Vector2 &size, const Color &color)
     : scene::GameObject(name, position), m_size(size), m_color(color) {}
 
-void Quad::OnUpdate(Context &c) {}
+void Quad::OnUpdate(const EngineContext &c) {}
 
-void Quad::OnStart(Context &c) {}
+void Quad::OnStart(const EngineContext &c) {}
 
-void Quad::Render(const Context &c) const {
+void Quad::Render(const EngineContext &c) const {
     Vector2 pos = this->GetPosition();
     Vector2 offset =
         Vector2(c.windowWidth - GameData::GridSize,

--- a/src/mvp/objects/Quad.hpp
+++ b/src/mvp/objects/Quad.hpp
@@ -8,9 +8,9 @@ public:
     Quad(const std::string &name, const Vector3 &position, const Vector2 &size,
          const Color &color);
 
-    void OnUpdate() override;
-    void OnStart() override;
-    void Render(const renderer::RendererContext &r) const override;
+    void OnUpdate(Context &c) override;
+    void OnStart(Context &c) override;
+    void Render(const Context &c) const override;
 
 private:
     Color m_color;

--- a/src/mvp/objects/Quad.hpp
+++ b/src/mvp/objects/Quad.hpp
@@ -8,9 +8,9 @@ public:
     Quad(const std::string &name, const Vector3 &position, const Vector2 &size,
          const Color &color);
 
-    void OnUpdate(Context &c) override;
-    void OnStart(Context &c) override;
-    void Render(const Context &c) const override;
+    void OnUpdate(const EngineContext &c) override;
+    void OnStart(const EngineContext &c) override;
+    void Render(const EngineContext &c) const override;
 
 private:
     Color m_color;

--- a/src/mvp/objects/Ship.cpp
+++ b/src/mvp/objects/Ship.cpp
@@ -9,7 +9,7 @@ Ship::Ship(const ShipData &data, const Vector2 &size, const Texture &source)
              size, source, Ship::ShipTypeToTexOffset(data.type)),
       m_data(data) {}
 
-void Ship::OnUpdate(Context &c) {
+void Ship::OnUpdate(const EngineContext &c) {
     const Vector2 pos = GetPosition();
     Vector2 target = pos;
     if (m_data.owner % 2 == 1) {
@@ -32,7 +32,7 @@ void Ship::OnUpdate(Context &c) {
     onChanged.Invoke(this, e);
 }
 
-void Ship::OnStart(Context &c) {}
+void Ship::OnStart(const EngineContext &c) {}
 
 Vector2 Ship::CalcOrigin() const {
     return GetPosition() * GameData::CellSize - Vector2(0, GameData::CellSize);

--- a/src/mvp/objects/Ship.cpp
+++ b/src/mvp/objects/Ship.cpp
@@ -9,7 +9,7 @@ Ship::Ship(const ShipData &data, const Vector2 &size, const Texture &source)
              size, source, Ship::ShipTypeToTexOffset(data.type)),
       m_data(data) {}
 
-void Ship::OnUpdate() {
+void Ship::OnUpdate(Context &c) {
     const Vector2 pos = GetPosition();
     Vector2 target = pos;
     if (m_data.owner % 2 == 1) {
@@ -32,7 +32,7 @@ void Ship::OnUpdate() {
     onChanged.Invoke(this, e);
 }
 
-void Ship::OnStart() {}
+void Ship::OnStart(Context &c) {}
 
 Vector2 Ship::CalcOrigin() const {
     return GetPosition() * GameData::CellSize - Vector2(0, GameData::CellSize);

--- a/src/mvp/objects/Ship.hpp
+++ b/src/mvp/objects/Ship.hpp
@@ -10,8 +10,8 @@ public:
 
     Ship(const ShipData &data, const Vector2 &size, const Texture &source);
 
-    void OnUpdate() override;
-    void OnStart() override;
+    void OnUpdate(Context &c) override;
+    void OnStart(Context &c) override;
 
     void SetHealth(uint16_t health) { m_data.health = health; }
     uint16_t GetHealth() const { return m_data.health; }

--- a/src/mvp/objects/Ship.hpp
+++ b/src/mvp/objects/Ship.hpp
@@ -10,8 +10,8 @@ public:
 
     Ship(const ShipData &data, const Vector2 &size, const Texture &source);
 
-    void OnUpdate(Context &c) override;
-    void OnStart(Context &c) override;
+    void OnUpdate(const EngineContext &c) override;
+    void OnStart(const EngineContext &c) override;
 
     void SetHealth(uint16_t health) { m_data.health = health; }
     uint16_t GetHealth() const { return m_data.health; }

--- a/src/mvp/objects/Sprite.cpp
+++ b/src/mvp/objects/Sprite.cpp
@@ -24,10 +24,9 @@ void Sprite::OnStart(const EngineContext &c) {}
 void Sprite::Render(const EngineContext &c) const {
     const Vector2 org = this->CalcOrigin();
     const Vector2 offset =
-        Vector2(static_cast<float>(c.windowWidth) - GameData::GridSize,
-                static_cast<float>(c.windowHeight) - GameData::GridSize -
-                    2 * GameData::CellSize) /
-        2;
+        (c.windowSize - Vector2(GameData::GridSize,
+                                GameData::GridSize + 2 * GameData::CellSize)) /
+        2.f;
     renderer::Renderer::DrawSprite(m_source, org + offset, m_texOffset,
                                    m_texSize, m_size / m_texSize);
 }

--- a/src/mvp/objects/Sprite.cpp
+++ b/src/mvp/objects/Sprite.cpp
@@ -17,15 +17,15 @@ Sprite::Sprite(const std::string &name, float order, const Vector2 &position,
     : scene::GameObject(name, order, position), m_size(size), m_source(source),
       m_texSize(texSize), m_texOffset(texOffset) {}
 
-void Sprite::OnUpdate() {}
+void Sprite::OnUpdate(Context &c) {}
 
-void Sprite::OnStart() {}
+void Sprite::OnStart(Context &c) {}
 
-void Sprite::Render(const renderer::RendererContext &r) const {
+void Sprite::Render(const Context &c) const {
     const Vector2 org = this->CalcOrigin();
     const Vector2 offset =
-        Vector2(static_cast<float>(r.windowWidth) - GameData::GridSize,
-                static_cast<float>(r.windowHeight) - GameData::GridSize -
+        Vector2(static_cast<float>(c.windowWidth) - GameData::GridSize,
+                static_cast<float>(c.windowHeight) - GameData::GridSize -
                     2 * GameData::CellSize) /
         2;
     renderer::Renderer::DrawSprite(m_source, org + offset, m_texOffset,

--- a/src/mvp/objects/Sprite.cpp
+++ b/src/mvp/objects/Sprite.cpp
@@ -17,11 +17,11 @@ Sprite::Sprite(const std::string &name, float order, const Vector2 &position,
     : scene::GameObject(name, order, position), m_size(size), m_source(source),
       m_texSize(texSize), m_texOffset(texOffset) {}
 
-void Sprite::OnUpdate(Context &c) {}
+void Sprite::OnUpdate(const EngineContext &c) {}
 
-void Sprite::OnStart(Context &c) {}
+void Sprite::OnStart(const EngineContext &c) {}
 
-void Sprite::Render(const Context &c) const {
+void Sprite::Render(const EngineContext &c) const {
     const Vector2 org = this->CalcOrigin();
     const Vector2 offset =
         Vector2(static_cast<float>(c.windowWidth) - GameData::GridSize,

--- a/src/mvp/objects/Sprite.hpp
+++ b/src/mvp/objects/Sprite.hpp
@@ -13,9 +13,9 @@ public:
            const Vector2 &size, const Texture &source, const Vector2 &texOffset,
            const Vector2 &texSize = Vector2(GameData::SpriteSize));
 
-    virtual void OnUpdate() override;
-    virtual void OnStart() override;
-    void Render(const renderer::RendererContext &r) const override;
+    virtual void OnUpdate(Context &c) override;
+    virtual void OnStart(Context &c) override;
+    void Render(const Context &c) const override;
 
 protected:
     virtual inline Vector2 CalcOrigin() const { return GetPosition(); }

--- a/src/mvp/objects/Sprite.hpp
+++ b/src/mvp/objects/Sprite.hpp
@@ -13,9 +13,9 @@ public:
            const Vector2 &size, const Texture &source, const Vector2 &texOffset,
            const Vector2 &texSize = Vector2(GameData::SpriteSize));
 
-    virtual void OnUpdate(Context &c) override;
-    virtual void OnStart(Context &c) override;
-    void Render(const Context &c) const override;
+    virtual void OnUpdate(const EngineContext &c) override;
+    virtual void OnStart(const EngineContext &c) override;
+    void Render(const EngineContext &c) const override;
 
 protected:
     virtual inline Vector2 CalcOrigin() const { return GetPosition(); }

--- a/src/test/depthOrderedCollection.test.cpp
+++ b/src/test/depthOrderedCollection.test.cpp
@@ -10,9 +10,9 @@ class TestObject : public scene::GameObject {
 public:
     TestObject(const std::string &name, float order, const Vector2 &pos)
         : scene::GameObject(name, order, pos) {}
-    void OnStart(Context &c) {}
-    void OnUpdate(Context &c) {}
-    void Render(const Context &c) const {}
+    void OnStart(const EngineContext &c) {}
+    void OnUpdate(const EngineContext &c) {}
+    void Render(const EngineContext &c) const {}
 };
 
 class TestInitialSize : public TestCaseBase {

--- a/src/test/depthOrderedCollection.test.cpp
+++ b/src/test/depthOrderedCollection.test.cpp
@@ -10,9 +10,9 @@ class TestObject : public scene::GameObject {
 public:
     TestObject(const std::string &name, float order, const Vector2 &pos)
         : scene::GameObject(name, order, pos) {}
-    void OnStart() {}
-    void OnUpdate() {}
-    void Render(const renderer::RendererContext &r) const {}
+    void OnStart(Context &c) {}
+    void OnUpdate(Context &c) {}
+    void Render(const Context &c) const {}
 };
 
 class TestInitialSize : public TestCaseBase {

--- a/src/test/gameObject.test.cpp
+++ b/src/test/gameObject.test.cpp
@@ -58,7 +58,7 @@ public:
 
     void OnUpdate(const EngineContext &c) override {
         Vector2 position = this->GetPosition();
-        float x = position.x() + CELL_SPEED * c.deltaTime;
+        float x = position.x() + CELL_SPEED * static_cast<float>(c.deltaTime);
         while (x > WINDOW_WIDTH) {
             x = -CELL_SIZE + (x - WINDOW_WIDTH);
         }
@@ -67,17 +67,13 @@ public:
     }
 
     void Render(const EngineContext &c) const override {
-        Vector2 pos = this->GetPosition();
+        const Vector2 pos = this->GetPosition();
         // Calculate scaling
-        const float x = static_cast<float>(c.windowWidth) /
-                        static_cast<float>(WINDOW_WIDTH);
-        const float y = static_cast<float>(c.windowHeight) /
-                        static_cast<float>(WINDOW_HEIGHT);
-
-        const Vector2 size(CELL_SIZE * x, CELL_SIZE * y);
-        pos[0] *= x;
-        pos[1] *= y;
-        renderer::Renderer::DrawRectangle(pos, size, this->m_color);
+        const Vector2 scale =
+            c.windowSize / Vector2(static_cast<float>(WINDOW_WIDTH),
+                                   static_cast<float>(WINDOW_HEIGHT));
+        const Vector2 size = scale * CELL_SIZE;
+        renderer::Renderer::DrawRectangle(pos * scale, size, this->m_color);
     }
 };
 
@@ -88,7 +84,7 @@ public:
         : scene::GameObject(name, -1, Vector2(0)),
           m_textElement(std::move(textElement)) {}
 
-    void OnStart(const EngineContext &c) override {
+    void OnStart(const EngineContext &) override {
         m_time = std::chrono::high_resolution_clock::now();
     }
 
@@ -103,11 +99,11 @@ public:
     void Render(const EngineContext &c) const override {}
 
 private:
-    std::chrono::_V2::system_clock::time_point m_time;
+    std::chrono::time_point<std::chrono::high_resolution_clock> m_time;
     std::shared_ptr<UI::TextElement> m_textElement;
 };
 
-int main(int argc, char *argv[]) {
+int main(int, char *[]) {
     Engine engine("Renderer Test", WINDOW_WIDTH, WINDOW_HEIGHT, true);
     engine.AddGameObject(scene::GameObject::CreateFromDerived(
         CellObject("1", Vector3(0, 0, 2), Color::BLUE)));

--- a/src/test/gameObject.test.cpp
+++ b/src/test/gameObject.test.cpp
@@ -58,7 +58,7 @@ public:
 
     void OnUpdate(const EngineContext &c) override {
         Vector2 position = this->GetPosition();
-        float x = position.x() + CELL_SPEED * c.DeltaTime();
+        float x = position.x() + CELL_SPEED * c.deltaTime;
         while (x > WINDOW_WIDTH) {
             x = -CELL_SIZE + (x - WINDOW_WIDTH);
         }
@@ -94,8 +94,8 @@ public:
 
     void OnUpdate(const EngineContext &c) override {
         char fpsString[FPS_BUFFER_SIZE];
-        if (sprintf(fpsString, "DT = %f, FPS: %f", c.DeltaTime(),
-                    1.f / c.DeltaTime()) > 0) {
+        if (sprintf(fpsString, "DT = %f, FPS: %f", c.deltaTime,
+                    1.f / c.deltaTime) > 0) {
             m_textElement->SetText(std::string(fpsString));
         }
     }

--- a/src/test/gameObject.test.cpp
+++ b/src/test/gameObject.test.cpp
@@ -12,7 +12,6 @@
 
 using namespace admirals;
 
-#define SECONDS_PER_MICROSECOND 1000000.f
 #define FPS_BUFFER_SIZE 100
 
 const int WINDOW_WIDTH = 1000;
@@ -21,7 +20,6 @@ const int CELL_SIZE = 100;
 const float CELL_SPEED = 500.f;
 const std::vector<Color> COLOR_LOOP = {Color::BLUE, Color::RED, Color::GREEN,
                                        Color::BLACK};
-float deltaT = 0;
 
 class CellObject : public scene::GameObject {
 private:
@@ -31,7 +29,7 @@ public:
     CellObject(const std::string &name, const Vector3 &pos, const Color &color)
         : scene::GameObject(name, pos), m_color(color) {}
 
-    void OnStart() override {}
+    void OnStart(Context &c) override {}
 
     void OnClick(void *, events::MouseCLickEventArgs e) {
         if (e.button != events::MouseButton::Left || !e.pressed) {
@@ -58,9 +56,9 @@ public:
         }
     }
 
-    void OnUpdate() override {
+    void OnUpdate(Context &c) override {
         Vector2 position = this->GetPosition();
-        float x = position.x() + CELL_SPEED * deltaT;
+        float x = position.x() + CELL_SPEED * c.DeltaTime();
         while (x > WINDOW_WIDTH) {
             x = -CELL_SIZE + (x - WINDOW_WIDTH);
         }
@@ -68,12 +66,12 @@ public:
         this->SetPosition(position);
     }
 
-    void Render(const renderer::RendererContext &r) const override {
+    void Render(const Context &c) const override {
         Vector2 pos = this->GetPosition();
         // Calculate scaling
-        const float x = static_cast<float>(r.windowWidth) /
+        const float x = static_cast<float>(c.windowWidth) /
                         static_cast<float>(WINDOW_WIDTH);
-        const float y = static_cast<float>(r.windowHeight) /
+        const float y = static_cast<float>(c.windowHeight) /
                         static_cast<float>(WINDOW_HEIGHT);
 
         const Vector2 size(CELL_SIZE * x, CELL_SIZE * y);
@@ -90,24 +88,19 @@ public:
         : scene::GameObject(name, -1, Vector2(0)),
           m_textElement(std::move(textElement)) {}
 
-    void OnStart() override {
+    void OnStart(Context &c) override {
         m_time = std::chrono::high_resolution_clock::now();
     }
 
-    void OnUpdate() override {
-        auto time = std::chrono::high_resolution_clock::now();
-        deltaT =
-            std::chrono::duration_cast<std::chrono::microseconds>(time - m_time)
-                .count() /
-            SECONDS_PER_MICROSECOND;
+    void OnUpdate(Context &c) override {
         char fpsString[FPS_BUFFER_SIZE];
-        if (sprintf(fpsString, "DT = %f, FPS: %f", deltaT, 1.f / deltaT) > 0) {
+        if (sprintf(fpsString, "DT = %f, FPS: %f", c.DeltaTime(),
+                    1.f / c.DeltaTime()) > 0) {
             m_textElement->SetText(std::string(fpsString));
         }
-        m_time = time;
     }
 
-    void Render(const renderer::RendererContext &r) const override {}
+    void Render(const Context &c) const override {}
 
 private:
     std::chrono::_V2::system_clock::time_point m_time;

--- a/src/test/gameObject.test.cpp
+++ b/src/test/gameObject.test.cpp
@@ -29,7 +29,7 @@ public:
     CellObject(const std::string &name, const Vector3 &pos, const Color &color)
         : scene::GameObject(name, pos), m_color(color) {}
 
-    void OnStart(Context &c) override {}
+    void OnStart(const EngineContext &c) override {}
 
     void OnClick(void *, events::MouseCLickEventArgs e) {
         if (e.button != events::MouseButton::Left || !e.pressed) {
@@ -56,7 +56,7 @@ public:
         }
     }
 
-    void OnUpdate(Context &c) override {
+    void OnUpdate(const EngineContext &c) override {
         Vector2 position = this->GetPosition();
         float x = position.x() + CELL_SPEED * c.DeltaTime();
         while (x > WINDOW_WIDTH) {
@@ -66,7 +66,7 @@ public:
         this->SetPosition(position);
     }
 
-    void Render(const Context &c) const override {
+    void Render(const EngineContext &c) const override {
         Vector2 pos = this->GetPosition();
         // Calculate scaling
         const float x = static_cast<float>(c.windowWidth) /
@@ -88,11 +88,11 @@ public:
         : scene::GameObject(name, -1, Vector2(0)),
           m_textElement(std::move(textElement)) {}
 
-    void OnStart(Context &c) override {
+    void OnStart(const EngineContext &c) override {
         m_time = std::chrono::high_resolution_clock::now();
     }
 
-    void OnUpdate(Context &c) override {
+    void OnUpdate(const EngineContext &c) override {
         char fpsString[FPS_BUFFER_SIZE];
         if (sprintf(fpsString, "DT = %f, FPS: %f", c.DeltaTime(),
                     1.f / c.DeltaTime()) > 0) {
@@ -100,7 +100,7 @@ public:
         }
     }
 
-    void Render(const Context &c) const override {}
+    void Render(const EngineContext &c) const override {}
 
 private:
     std::chrono::_V2::system_clock::time_point m_time;

--- a/src/test/renderer.test.cpp
+++ b/src/test/renderer.test.cpp
@@ -41,17 +41,12 @@ public:
     }
 
     void Render(const EngineContext &c) const override {
-        float x = static_cast<float>(c.windowWidth) /
-                  static_cast<float>(m_texture.Width());
-        float y = static_cast<float>(c.windowHeight) /
-                  static_cast<float>(m_texture.Height());
+        Vector2 scale = c.windowSize / m_texture.Size();
         if (m_keepAspectRatio) {
-            x = std::min(x, y);
-            y = x;
+            scale[0] = scale[1] = std::min(scale.x(), scale.y());
         }
 
-        renderer::Renderer::DrawTexture(m_texture, GetPosition(),
-                                        Vector2(x, y));
+        renderer::Renderer::DrawTexture(m_texture, GetPosition(), scale);
     }
 
 private:
@@ -104,7 +99,7 @@ void CreateEscapeMenuOptions(std::shared_ptr<menu::Menu> escapeMenu,
 }
 
 void OnButtonClick(void *object, events::ButtonClickEventArgs &event) {
-    auto button = static_cast<Button *>(object);
+    auto *button = static_cast<Button *>(object);
     if (event.m_data.type == SDL_MOUSEBUTTONUP) {
         button->SetBackgroundColor(Color::BLACK);
     } else if (event.m_data.type == SDL_MOUSEBUTTONDOWN) {

--- a/src/test/renderer.test.cpp
+++ b/src/test/renderer.test.cpp
@@ -25,9 +25,9 @@ public:
         : scene::GameObject(name, pos), m_keepAspectRatio(keepAspectRatio),
           m_texture(Texture::LoadFromPath(texturePath)) {}
 
-    void OnStart() override {}
+    void OnStart(Context &c) override {}
 
-    void OnUpdate() override {}
+    void OnUpdate(Context &c) override {}
 
     void ButtonClickHandler(void *sender, events::ButtonClickEventArgs &e) {
         if (e.m_data.type != SDL_MOUSEBUTTONDOWN)
@@ -40,10 +40,10 @@ public:
         }
     }
 
-    void Render(const renderer::RendererContext &r) const override {
-        float x = static_cast<float>(r.windowWidth) /
+    void Render(const Context &c) const override {
+        float x = static_cast<float>(c.windowWidth) /
                   static_cast<float>(m_texture.Width());
-        float y = static_cast<float>(r.windowHeight) /
+        float y = static_cast<float>(c.windowHeight) /
                   static_cast<float>(m_texture.Height());
         if (m_keepAspectRatio) {
             x = std::min(x, y);

--- a/src/test/renderer.test.cpp
+++ b/src/test/renderer.test.cpp
@@ -25,9 +25,9 @@ public:
         : scene::GameObject(name, pos), m_keepAspectRatio(keepAspectRatio),
           m_texture(Texture::LoadFromPath(texturePath)) {}
 
-    void OnStart(Context &c) override {}
+    void OnStart(const EngineContext &) override {}
 
-    void OnUpdate(Context &c) override {}
+    void OnUpdate(const EngineContext &) override {}
 
     void ButtonClickHandler(void *sender, events::ButtonClickEventArgs &e) {
         if (e.m_data.type != SDL_MOUSEBUTTONDOWN)
@@ -40,7 +40,7 @@ public:
         }
     }
 
-    void Render(const Context &c) const override {
+    void Render(const EngineContext &c) const override {
         float x = static_cast<float>(c.windowWidth) /
                   static_cast<float>(m_texture.Width());
         float y = static_cast<float>(c.windowHeight) /

--- a/src/test/scene.test.cpp
+++ b/src/test/scene.test.cpp
@@ -12,11 +12,11 @@ public:
     CellObject(const std::string &name, const Vector3 &pos)
         : scene::GameObject(name, pos) {}
 
-    void OnStart() {}
+    void OnStart(Context &c) {}
 
-    void OnUpdate() {}
+    void OnUpdate(Context &c) {}
 
-    void Render(const renderer::RendererContext &r) const {}
+    void Render(const Context &c) const {}
 };
 
 int test_add() {

--- a/src/test/scene.test.cpp
+++ b/src/test/scene.test.cpp
@@ -12,11 +12,11 @@ public:
     CellObject(const std::string &name, const Vector3 &pos)
         : scene::GameObject(name, pos) {}
 
-    void OnStart(Context &c) {}
+    void OnStart(const EngineContext &c) {}
 
-    void OnUpdate(Context &c) {}
+    void OnUpdate(const EngineContext &c) {}
 
-    void Render(const Context &c) const {}
+    void Render(const EngineContext &c) const {}
 };
 
 int test_add() {


### PR DESCRIPTION
Adds the `Context` class as part of the engine. With this, the renderer context has been removed and its contents placed in Context. The renderer and the render functions (including all implemented objects) have been modified to reflect this.

Additionally, the context is now included in both `OnStart()` and `OnUpdate()` to allow for them to use it. At the moment only `DeltaTime` is implemented, but more can be added to it in the future if we see fit.

The menu and gameObject test have been modified to use DeltaTime from the context