### PR TITLE
Reduced unnecessary server calls in the MVP

### DIFF
--- a/src/mvp/objects/GameManager.cpp
+++ b/src/mvp/objects/GameManager.cpp
@@ -47,7 +47,13 @@ void GameManager::StopGame() {
     }
 }
 
-void GameManager::BuyShip(uint8_t type) { m_networkManager->BuyShip(type); }
+void GameManager::BuyShip(uint8_t type) {
+    if (m_coins < ShipInfoMap[type].Cost) {
+        return;
+    }
+
+    m_networkManager->BuyShip(type);
+}
 
 void GameManager::MoveShip(uint16_t id, int x, int y) {
     if (m_ships.find(id) == m_ships.end() ||

--- a/src/mvp/objects/GameManager.cpp
+++ b/src/mvp/objects/GameManager.cpp
@@ -50,10 +50,21 @@ void GameManager::StopGame() {
 void GameManager::BuyShip(uint8_t type) { m_networkManager->BuyShip(type); }
 
 void GameManager::MoveShip(uint16_t id, int x, int y) {
+    if (m_ships.find(id) == m_ships.end() ||
+        m_ships[id]->GetPlayerId() != m_playerId) {
+        return;
+    }
+
     m_networkManager->MoveShip(id, x, y);
 }
 
 void GameManager::AttackShip(uint16_t id, uint16_t targetId) {
+    if (m_ships.find(id) == m_ships.end() ||
+        m_ships.find(targetId) == m_ships.end() ||
+        m_ships[id]->GetPlayerId() != m_playerId) {
+        return;
+    }
+
     m_networkManager->AttackShip(id, targetId);
 }
 
@@ -99,6 +110,7 @@ void GameManager::ModifyShips(const std::map<uint16_t, ShipData> &ships) {
         if (it != m_ships.end()) {
             it->second->SetPosition(ship.x, ship.y);
             it->second->SetHealth(ship.health);
+            it->second->SetAction(ship.action);
         } else {
             if (m_debug)
                 printf("Creating ship %d\n", ship.id);

--- a/src/mvp/objects/Ship.cpp
+++ b/src/mvp/objects/Ship.cpp
@@ -25,11 +25,14 @@ void Ship::OnUpdate() {
             target[1] -= 1;
         }
     }
-    m_data.action = ShipAction::Move;
-    m_data.moveData.actionX = static_cast<uint8_t>(target.x());
-    m_data.moveData.actionY = static_cast<uint8_t>(target.y());
-    events::EventArgs e;
-    onChanged.Invoke(this, e);
+
+    if (m_data.action == ShipAction::None) {
+        m_data.action = ShipAction::Move;
+        m_data.moveData.actionX = static_cast<uint8_t>(target.x());
+        m_data.moveData.actionY = static_cast<uint8_t>(target.y());
+        events::EventArgs e;
+        onChanged.Invoke(this, e);
+    }
 }
 
 void Ship::OnStart() {}


### PR DESCRIPTION
This small change introduces various checks to the MVP to remove unnecessary calls to the server.

`BuyShip()`, `MoveShip()`, and `AttackShip()` can now stop early to avoid server calls.

A check has been added to the current moving ships to avoid them sending more move commands if one has already been sent. When we continue with the MVP, I believe it should be up to the game objects to do their own checks (like ship does now) so that each object can have its own restrictions.   