### PR TITLE
InputOption, MenuOption(s) hover effect and Cursor altering.

### DIFF
--- a/src/engine/Renderer.cpp
+++ b/src/engine/Renderer.cpp
@@ -56,6 +56,7 @@ int Renderer::Init(const EngineContext &ctx) {
         ctx.windowSize.y(),       1, 0};
 
     vk2dRendererSetCamera(camera);
+
     return code;
 }
 
@@ -143,4 +144,10 @@ void Renderer::DrawText(const Texture &font, const Vector2 &position,
     vk2dRendererSetColourMod(color.Data());
     RenderFont(font.Data(), position, text.c_str());
     vk2dRendererSetColourMod(VK2D_DEFAULT_COLOUR_MOD);
+}
+
+void Renderer::SetCursor(Cursor cursor) {
+    SDL_Cursor *c;
+    c = SDL_CreateSystemCursor(static_cast<SDL_SystemCursor>(cursor));
+    SDL_SetCursor(c);
 }

--- a/src/engine/Renderer.hpp
+++ b/src/engine/Renderer.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include <SDL_mouse.h>
 #include <SDL_video.h>
 #include <VK2D/Texture.h>
 
@@ -14,6 +15,11 @@
 namespace admirals::renderer {
 
 typedef std::vector<std::shared_ptr<IDrawable>> DrawableCollection;
+
+enum Cursor {
+    Arrow = SDL_SYSTEM_CURSOR_ARROW,
+    Hand = SDL_SYSTEM_CURSOR_HAND,
+};
 
 class Renderer {
 public:
@@ -50,6 +56,8 @@ public:
 
     static void DrawText(const Texture &font, const Vector2 &position,
                          const Color &color, const std::string &text);
+
+    static void SetCursor(Cursor cursor);
 
     static inline Vector2 TextFontSize(const std::string &text, float width,
                                        float height) {

--- a/src/engine/UI/DisplayLayout.cpp
+++ b/src/engine/UI/DisplayLayout.cpp
@@ -64,6 +64,10 @@ void DisplayLayout::OnClick(events::MouseClickEventArgs &args) {
 }
 
 void DisplayLayout::OnMouseMove(events::MouseMotionEventArgs &args) {
+    // TODO: This currentl handles MouseEnter/MouseMove before any MouseLeave
+    // events, which is reverse of what is happening chronologically. Instead,
+    // one might want to handle MouseLeave events first.
+    //
     const Vector2 mouseLocation = args.Location();
     std::unordered_set<std::string> currentMouseOverElements;
 

--- a/src/engine/UI/menu/MenuOption.cpp
+++ b/src/engine/UI/menu/MenuOption.cpp
@@ -9,7 +9,7 @@ MenuOption::MenuOption(const std::string &name, float order,
     : Element(name, order, text, Vector2(0, 0)) {}
 
 void MenuOption::Render(const EngineContext &ctx) const {
-    if (m_clickedAndShouldDrawBackground) {
+    if (m_shouldDrawBackground) {
         renderer::Renderer::DrawRectangle(m_boundingBox, Color::GREY);
     }
 
@@ -19,6 +19,20 @@ void MenuOption::Render(const EngineContext &ctx) const {
 
 void MenuOption::OnClick(events::MouseClickEventArgs &args) {
     onClick.Invoke(this, args);
+}
+
+void MenuOption::OnMouseEnter(events::MouseMotionEventArgs &) {
+    m_shouldDrawBackground = true;
+    renderer::Renderer::SetCursor(renderer::Cursor::Hand);
+}
+
+void MenuOption::OnMouseLeave(events::MouseMotionEventArgs &) {
+    m_shouldDrawBackground = false;
+    renderer::Renderer::SetCursor(renderer::Cursor::Arrow);
+}
+
+void MenuOption::OnMouseMove(events::MouseMotionEventArgs &) {
+    renderer::Renderer::SetCursor(renderer::Cursor::Hand);
 }
 
 // TextOption
@@ -78,7 +92,7 @@ InputOption::InputOption(const std::string &name, float order,
     : MenuOption(name, order, ""), m_placeholderText(placeholder) {}
 
 void InputOption::Render(const EngineContext &ctx) const {
-    if (m_isActive || m_clickedAndShouldDrawBackground) {
+    if (m_isActive || m_shouldDrawBackground) {
         renderer::Renderer::DrawRectangle(m_boundingBox, Color::GREY);
     }
 

--- a/src/engine/UI/menu/MenuOption.cpp
+++ b/src/engine/UI/menu/MenuOption.cpp
@@ -72,3 +72,39 @@ void CycleOption::Cycle() {
 }
 
 size_t CycleOption::CurrentIndex() const { return m_currentOption; }
+
+InputOption::InputOption(const std::string &name, float order,
+                         const std::string &placeholder)
+    : MenuOption(name, order, ""), m_placeholderText(placeholder) {}
+
+void InputOption::Render(const EngineContext &ctx) const {
+    if (m_isActive || m_clickedAndShouldDrawBackground) {
+        renderer::Renderer::DrawRectangle(m_boundingBox, Color::GREY);
+    }
+
+    renderer::Renderer::DrawText(*ctx.fontTexture, m_boundingBox.Position(),
+                                 m_textColor, GetOptionText());
+}
+
+std::string InputOption::GetOptionText() const {
+    if (m_inputText.length() == 0) {
+        return m_placeholderText;
+    }
+
+    return m_inputText;
+}
+
+void InputOption::HandleKeyPressEvent(events::KeyPressEventArgs &args) {
+    if (!args.isKeyUp) {
+        return;
+    }
+
+    // TODO: This only handles ASCII-values...
+    if (args.key == SDLK_BACKSPACE && m_inputText.length() > 0) {
+        m_inputText.pop_back();
+        args.handled = true;
+    } else if (args.key >= 32 && args.key <= 126) {
+        m_inputText.push_back((char)args.key);
+        args.handled = true;
+    }
+}

--- a/src/engine/UI/menu/MenuOption.hpp
+++ b/src/engine/UI/menu/MenuOption.hpp
@@ -39,7 +39,7 @@ public:
         return element;
     }
 
-private:
+protected:
     Color m_textColor;
     bool m_clickedAndShouldDrawBackground = false;
 };
@@ -93,6 +93,26 @@ public:
 private:
     size_t m_currentOption;
     std::vector<std::string> m_cycleOptions;
+};
+
+class InputOption : public MenuOption {
+public:
+    InputOption(const std::string &name, float order,
+                const std::string &placeholder = "...");
+
+    virtual void Render(const EngineContext &ctx) const override;
+
+    std::string GetOptionText() const override;
+
+    inline bool IsActive() const { return m_isActive; }
+    inline void ToggleActive() { m_isActive = !m_isActive; }
+
+    void HandleKeyPressEvent(events::KeyPressEventArgs &args);
+
+private:
+    std::string m_placeholderText;
+    std::string m_inputText;
+    bool m_isActive = false;
 };
 
 } // namespace admirals::UI::menu

--- a/src/engine/UI/menu/MenuOption.hpp
+++ b/src/engine/UI/menu/MenuOption.hpp
@@ -6,6 +6,7 @@
 #include "DataObjects.hpp"
 #include "UI/Element.hpp"
 #include "events/EventSystem.hpp"
+#include "events/KeyPressEvent.hpp"
 #include "events/MouseClickEvent.hpp"
 
 namespace admirals::UI::menu {
@@ -22,13 +23,12 @@ public:
     virtual void Render(const EngineContext &ctx) const override;
 
     void OnClick(events::MouseClickEventArgs &args) override;
+    virtual void OnMouseEnter(events::MouseMotionEventArgs &args) override;
+    virtual void OnMouseLeave(events::MouseMotionEventArgs &args) override;
+    virtual void OnMouseMove(events::MouseMotionEventArgs &args) override;
 
     virtual std::string GetOptionText() const = 0;
     inline void SetTextColor(const Color &color) { m_textColor = color; }
-
-    inline void SetDrawBackground(bool value) {
-        m_clickedAndShouldDrawBackground = value;
-    }
 
     template <typename T>
     static std::shared_ptr<MenuOption>
@@ -41,7 +41,7 @@ public:
 
 protected:
     Color m_textColor;
-    bool m_clickedAndShouldDrawBackground = false;
+    bool m_shouldDrawBackground = false;
 };
 
 // Text Option, is non-interactive.

--- a/src/test/renderer.test.cpp
+++ b/src/test/renderer.test.cpp
@@ -52,6 +52,14 @@ private:
     bool m_keepAspectRatio;
 };
 
+// Global inputOption for visibility in other functions.
+std::shared_ptr<menu::InputOption> inputOption =
+    std::make_shared<menu::InputOption>("inputOption", 1.0);
+
+void HandleEscapeMenuInput(void *, events::KeyPressEventArgs &args) {
+    inputOption->HandleKeyPressEvent(args);
+}
+
 void CreateEscapeMenuOptions(std::shared_ptr<menu::Menu> escapeMenu,
                              Engine &engine, bool initialDebugValue) {
     menu::ClickOption exitOption("exitOption", 1.0, "Exit...");
@@ -63,6 +71,21 @@ void CreateEscapeMenuOptions(std::shared_ptr<menu::Menu> escapeMenu,
             engine.StopGameLoop();
         });
     escapeMenu->AddMenuOption(menu::MenuOption::CreateFromDerived(exitOption));
+
+    inputOption->onClick.Subscribe(
+        [&engine](void *sender, events::MouseClickEventArgs &args) {
+            if (args.pressed) {
+                auto *inputOption = static_cast<menu::InputOption *>(sender);
+                inputOption->ToggleActive();
+
+                if (inputOption->IsActive()) {
+                    engine.onKeyPress.Subscribe(HandleEscapeMenuInput);
+                } else {
+                    engine.onKeyPress.Unsubscribe(HandleEscapeMenuInput);
+                }
+            }
+        });
+    escapeMenu->AddMenuOption(inputOption);
 
     menu::ToggleOption toggleDebugOption("toggleDebugRenderingOption", 1.0,
                                          "Debug Rendering", initialDebugValue);


### PR DESCRIPTION
This PR implements a new menu option called `InputOption` for text input in a menu as well as fixed hover effects on MenuOption(s) using the new `(on)MouseEnter/MouseLeave/MouseHover` events.

To this I have also added a primitive way of changing the current cursor using a static method in the Renderer (which I felt was the most appropriate place to have it). The hover effects on MenuOptions currently change the cursor to a "Hand" and restores the cursor back to the default "Arrow" when not hovering on an option. See image below for cursor and background.

![image](https://github.com/joelsiks/admirals/assets/21147276/187694cd-8313-495f-b540-fbbad9ccb299)


Fixes #85 
Fixes #90 