### PR TITLE
Fixes for InputOption and test file renaming. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,9 +112,9 @@ target_include_directories(mvp_server PRIVATE
 )
 
 # Create test executable
-add_executable(renderer_test src/test/renderer.test.cpp)
-target_link_libraries(renderer_test engine)
-target_include_directories(renderer_test PRIVATE 
+add_executable(ui_test src/test/ui.test.cpp)
+target_link_libraries(ui_test engine)
+target_include_directories(ui_test PRIVATE 
     "src/test/"
 )
 
@@ -154,8 +154,8 @@ target_include_directories(scene_test PRIVATE
 )
 
 # Copy SDL2.dll to the output directory after the executable is built
-add_custom_command(TARGET renderer_test POST_BUILD
+add_custom_command(TARGET ui_test POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         "${SDL2_DLL}"
-        $<TARGET_FILE_DIR:renderer_test>
+        $<TARGET_FILE_DIR:ui_test>
 )

--- a/src/engine/Renderer.cpp
+++ b/src/engine/Renderer.cpp
@@ -82,8 +82,9 @@ void Renderer::Render(const EngineContext &context,
         char fpsString[FPS_BUFFER_SIZE];
         if (sprintf(fpsString, "DT = %f, FPS: %f", context.deltaTime,
                     1.f / context.deltaTime) > 0) {
-            DrawText(*context.fontTexture, Vector2(0, 0), Color::RED,
-                     fpsString);
+            DrawText(*context.fontTexture,
+                     Vector2(0, context.windowSize.y() - context.fontHeight),
+                     Color::RED, fpsString);
         }
     }
 

--- a/src/engine/UI/menu/MenuOption.hpp
+++ b/src/engine/UI/menu/MenuOption.hpp
@@ -105,10 +105,20 @@ private:
 
 class InputOption : public MenuOption {
 public:
+    // Invoked when the text in the input is changed.
+    events::EventSystem<events::EventArgs> onInputChange;
+
     InputOption(const std::string &name, float order,
+                events::EventSystem<events::KeyPressEventArgs> &eventHandler,
                 const std::string &placeholder = "...");
 
     virtual void Render(const EngineContext &ctx) const override;
+
+    virtual void OnMouseEnter(events::MouseMotionEventArgs &args) override;
+    virtual void OnMouseLeave(events::MouseMotionEventArgs &args) override;
+    virtual void OnMouseMove(events::MouseMotionEventArgs &args) override;
+
+    virtual void OnHidden() override;
 
     std::string GetOptionText() const override;
 
@@ -117,10 +127,14 @@ public:
 
     void HandleKeyPressEvent(void *sender, events::KeyPressEventArgs &args);
 
+    inline std::string GetInputText() const { return m_inputText; }
+
 private:
     std::string m_placeholderText;
     std::string m_inputText;
     bool m_isActive = false;
+
+    events::EventSystem<events::KeyPressEventArgs> &m_keyPressEventHandler;
 };
 
 } // namespace admirals::UI::menu

--- a/src/test/ui.test.cpp
+++ b/src/test/ui.test.cpp
@@ -65,22 +65,12 @@ void CreateEscapeMenuOptions(std::shared_ptr<menu::Menu> escapeMenu,
     escapeMenu->AddMenuOption(menu::MenuOption::CreateFromDerived(exitOption));
 
     const std::shared_ptr<menu::InputOption> inputOption =
-        std::make_shared<menu::InputOption>("inputOption", 1.0);
-    inputOption->onClick.Subscribe(
-        [&engine](void *sender, events::MouseClickEventArgs &args) {
-            if (args.pressed) {
-                auto *inputOption = static_cast<menu::InputOption *>(sender);
-                inputOption->ToggleActive();
-
-                if (inputOption->IsActive()) {
-                    engine.onKeyPress.Subscribe(BIND_EVENT_HANDLER_FROM(
-                        menu::InputOption::HandleKeyPressEvent, inputOption));
-                } else {
-                    engine.onKeyPress.Unsubscribe(BIND_EVENT_HANDLER_FROM(
-                        menu::InputOption::HandleKeyPressEvent, inputOption));
-                }
-            }
-        });
+        std::make_shared<menu::InputOption>("inputOption", 1.0,
+                                            engine.onKeyPress);
+    inputOption->onInputChange.Subscribe([](void *sender, events::EventArgs &) {
+        auto *inputOption = static_cast<menu::InputOption *>(sender);
+        printf("Input was changed: %s\n", inputOption->GetInputText().c_str());
+    });
     escapeMenu->AddMenuOption(inputOption);
 
     menu::ToggleOption toggleDebugOption("toggleDebugRenderingOption", 1.0,
@@ -140,7 +130,7 @@ void CreateUIElements(Engine &engine,
 int main(int, char **) {
 
     const bool debug = true;
-    Engine engine("Renderer Test", WINDOW_WIDTH, WINDOW_HEIGHT, debug);
+    Engine engine("UI Test", WINDOW_WIDTH, WINDOW_HEIGHT, debug);
 
     auto escapeMenu = std::make_shared<menu::Menu>(
         "Pause Menu", Color::BLACK, Color::FromRGBA(50, 50, 50, 100));


### PR DESCRIPTION
This PR adds a fix for correct hovering and DisplayLayout swap for `InputOption`.

Additionally, I have also renamed `renderer.test.cpp` to `ui.test.cpp` and to `ui_test` in CMakeLists.txt.