### PR TITLE
Deferred layer switching/toggling

### DIFF
--- a/src/engine/DeferedAction.hpp
+++ b/src/engine/DeferedAction.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace admirals {
+
+enum DeferType {
+    None = 1,
+    Add,
+    Delete,
+    Activate,
+    Deactivate,
+};
+
+} // namespace admirals

--- a/src/engine/DeferedAction.hpp
+++ b/src/engine/DeferedAction.hpp
@@ -8,6 +8,7 @@ enum DeferType {
     Delete,
     Activate,
     Deactivate,
+    ToggleActive,
 };
 
 } // namespace admirals

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -125,6 +125,8 @@ void Engine::HandleDeferredToggleLayers() {
                 m_layers[layerIdx]->OnHidden();
             }
             break;
+        default:
+            break;
         }
     }
 

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -108,21 +108,24 @@ void Engine::HandleDeferredToggleLayers() {
         case DeferType::Add:
         case DeferType::Activate:
             if (m_layers.contains(layerIdx)) {
-                m_activeLayers.insert(layerIdx);
-                m_layers[layerIdx]->OnShown();
+                const bool inserted = m_activeLayers.insert(layerIdx).second;
+                if (inserted) {
+                    m_layers[layerIdx]->OnShown();
+                }
             }
             break;
         case DeferType::Delete:
-            m_activeLayers.erase(layerIdx);
-            m_layers.erase(layerIdx);
+            if (m_layers.erase(layerIdx) == 1) {
+                m_activeLayers.erase(layerIdx);
+            }
             break;
         case DeferType::Deactivate:
-            if (m_layers.contains(layerIdx)) {
-                m_activeLayers.erase(layerIdx);
+            if (m_layers.contains(layerIdx) &&
+                m_activeLayers.erase(layerIdx) == 1) {
                 m_layers[layerIdx]->OnHidden();
             }
             break;
-        };
+        }
     }
 
     m_deferredToggleLayers.clear();

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -100,6 +100,20 @@ bool Engine::PollAndHandleEvent() {
     return quit;
 }
 
+void Engine::HandleDeferredToggleLayers() {
+    for (const auto layerIdx : m_deferredToggleLayers) {
+        if (m_activeLayers.contains(layerIdx)) {
+            m_activeLayers.erase(layerIdx);
+            m_layers[layerIdx]->OnShown();
+        } else {
+            m_activeLayers.insert(layerIdx);
+            m_layers[layerIdx]->OnHidden();
+        }
+    }
+
+    m_deferredToggleLayers.clear();
+}
+
 void Engine::StartGameLoop() {
     m_running = true;
 
@@ -142,5 +156,7 @@ void Engine::StartGameLoop() {
         }
 
         m_renderer->Render(GetContext(), layers);
+
+        HandleDeferredToggleLayers();
     }
 }

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -101,8 +101,18 @@ bool Engine::PollAndHandleEvent() {
 }
 
 void Engine::HandleDeferredToggleLayers() {
-    for (const auto &deferPair : m_deferredToggleLayers) {
+    for (auto &deferPair : m_deferredToggleLayers) {
         const size_t layerIdx = deferPair.first;
+
+        if (deferPair.second == DeferType::ToggleActive) {
+            if (m_layers.contains(layerIdx)) {
+                if (m_activeLayers.contains(layerIdx)) {
+                    deferPair.second = DeferType::Deactivate;
+                } else {
+                    deferPair.second = DeferType::Activate;
+                }
+            }
+        }
 
         switch (deferPair.second) {
         case DeferType::Add:

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -114,6 +114,7 @@ void Engine::HandleDeferredToggleLayers() {
             break;
         case DeferType::Delete:
             m_activeLayers.erase(layerIdx);
+            m_layers.erase(layerIdx);
             break;
         case DeferType::Deactivate:
             if (m_layers.contains(layerIdx)) {

--- a/src/engine/Engine.hpp
+++ b/src/engine/Engine.hpp
@@ -54,12 +54,18 @@ public:
             return true;
         }
 
+        // If m_layers contains the idx and it is not in m_activeLayers we must
+        // search through all defered actions to see the layer's "final" state.
+        DeferType layerDef = DeferType::None;
         for (const auto &deferPair : m_deferredToggleLayers) {
             if (deferPair.first == idx) {
-                return (deferPair.second == DeferType::Add ||
-                        deferPair.second == DeferType::Activate);
+                layerDef = deferPair.second;
             }
         }
+
+        if (layerDef != DeferType::None)
+            return (layerDef == DeferType::Add ||
+                    layerDef == DeferType::Activate);
 
         return false;
     }
@@ -141,7 +147,8 @@ private:
     std::shared_ptr<Scene> m_scene;
 
     enum DeferType {
-        Add = 1,
+        None = 1,
+        Add,
         Delete,
         Activate,
         Deactivate,

--- a/src/engine/Engine.hpp
+++ b/src/engine/Engine.hpp
@@ -37,13 +37,8 @@ public:
         return wasInserted;
     }
 
-    inline bool DeleteLayer(size_t idx) {
-        const size_t elementsRemoved = m_layers.erase(idx);
-        if (elementsRemoved != 0) {
-            m_deferredToggleLayers.push_back({idx, DeferType::Delete});
-        }
-
-        return elementsRemoved != 0;
+    inline void DeleteLayer(size_t idx) {
+        m_deferredToggleLayers.push_back({idx, DeferType::Delete});
     }
 
     inline std::shared_ptr<IDisplayLayer> GetLayer(size_t idx) {

--- a/src/engine/Engine.hpp
+++ b/src/engine/Engine.hpp
@@ -56,25 +56,16 @@ public:
         return m_activeLayers.find(idx) != m_activeLayers.end();
     }
 
-    inline bool ActivateLayer(size_t idx) {
+    inline void ActivateLayer(size_t idx) {
         if (m_layers.find(idx) != m_layers.end() &&
             !(m_activeLayers.find(idx) != m_activeLayers.end())) {
-            const bool wasInserted = m_activeLayers.insert(idx).second;
-
-            if (wasInserted) {
-                m_layers[idx]->OnShown();
-            }
-
-            return wasInserted;
+            m_deferredToggleLayers.insert(idx);
         }
-
-        return false;
     }
 
     inline void DeactivateLayer(size_t idx) {
         if (m_activeLayers.find(idx) != m_activeLayers.end()) {
-            m_layers[idx]->OnHidden();
-            m_activeLayers.erase(idx);
+            m_deferredToggleLayers.insert(idx);
         }
     }
 
@@ -131,6 +122,8 @@ public:
 private:
     bool PollAndHandleEvent();
 
+    void HandleDeferredToggleLayers();
+
     bool m_running;
 
     std::string m_gameName;
@@ -143,7 +136,7 @@ private:
     // Drawables
     std::shared_ptr<Scene> m_scene;
     std::map<size_t, std::shared_ptr<IDisplayLayer>> m_layers;
-    std::unordered_set<size_t> m_activeLayers;
+    std::unordered_set<size_t> m_activeLayers, m_deferredToggleLayers;
 
     std::shared_ptr<renderer::Renderer> m_renderer;
     EngineContext m_context;

--- a/src/engine/Engine.hpp
+++ b/src/engine/Engine.hpp
@@ -32,14 +32,14 @@ public:
         const bool wasInserted = m_layers.emplace(idx, std::move(layer)).second;
 
         if (wasInserted && active) {
-            m_deferredToggleLayers.push_back({idx, DeferType::Add});
+            m_deferredLayerActions.push_back({idx, DeferType::Add});
         }
 
         return wasInserted;
     }
 
     inline void DeleteLayer(size_t idx) {
-        m_deferredToggleLayers.push_back({idx, DeferType::Delete});
+        m_deferredLayerActions.push_back({idx, DeferType::Delete});
     }
 
     inline std::shared_ptr<IDisplayLayer> GetLayer(size_t idx) {
@@ -55,15 +55,15 @@ public:
     }
 
     inline void ActivateLayer(size_t idx) {
-        m_deferredToggleLayers.push_back({idx, DeferType::Activate});
+        m_deferredLayerActions.push_back({idx, DeferType::Activate});
     }
 
     inline void DeactivateLayer(size_t idx) {
-        m_deferredToggleLayers.push_back({idx, DeferType::Deactivate});
+        m_deferredLayerActions.push_back({idx, DeferType::Deactivate});
     }
 
     inline void ToggleLayer(size_t idx) {
-        m_deferredToggleLayers.push_back({idx, DeferType::ToggleActive});
+        m_deferredLayerActions.push_back({idx, DeferType::ToggleActive});
     }
 
     inline void AddUIElement(std::shared_ptr<UI::Element> element,
@@ -109,7 +109,7 @@ public:
 private:
     bool PollAndHandleEvent();
 
-    void HandleDeferredToggleLayers();
+    void HandleDeferredLayerActions();
 
     bool m_running;
 
@@ -123,7 +123,7 @@ private:
     std::shared_ptr<Scene> m_scene;
     std::map<size_t, std::shared_ptr<IDisplayLayer>> m_layers;
     std::unordered_set<size_t> m_activeLayers;
-    std::vector<std::pair<size_t, DeferType>> m_deferredToggleLayers;
+    std::vector<std::pair<size_t, DeferType>> m_deferredLayerActions;
 
     std::shared_ptr<renderer::Renderer> m_renderer;
     EngineContext m_context;

--- a/src/engine/Engine.hpp
+++ b/src/engine/Engine.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "DeferedAction.hpp"
 #include "EngineContext.hpp"
 #include "GameObject.hpp"
 #include "IDisplayLayer.hpp"
@@ -145,14 +146,6 @@ private:
     inline bool hasActiveLayers() { return !m_activeLayers.empty(); }
 
     std::shared_ptr<Scene> m_scene;
-
-    enum DeferType {
-        None = 1,
-        Add,
-        Delete,
-        Activate,
-        Deactivate,
-    };
     std::map<size_t, std::shared_ptr<IDisplayLayer>> m_layers;
     std::unordered_set<size_t> m_activeLayers;
     std::vector<std::pair<size_t, DeferType>> m_deferredToggleLayers;

--- a/src/engine/Engine.hpp
+++ b/src/engine/Engine.hpp
@@ -51,44 +51,19 @@ public:
             return false;
         }
 
-        if (m_activeLayers.find(idx) != m_activeLayers.end()) {
-            return true;
-        }
-
-        // If m_layers contains the idx and it is not in m_activeLayers we must
-        // search through all defered actions to see the layer's "final" state.
-        DeferType layerDef = DeferType::None;
-        for (const auto &deferPair : m_deferredToggleLayers) {
-            if (deferPair.first == idx) {
-                layerDef = deferPair.second;
-            }
-        }
-
-        if (layerDef != DeferType::None)
-            return (layerDef == DeferType::Add ||
-                    layerDef == DeferType::Activate);
-
-        return false;
+        return m_activeLayers.find(idx) != m_activeLayers.end();
     }
 
     inline void ActivateLayer(size_t idx) {
-        if (!LayerIsActive(idx)) {
-            m_deferredToggleLayers.push_back({idx, DeferType::Activate});
-        }
+        m_deferredToggleLayers.push_back({idx, DeferType::Activate});
     }
 
     inline void DeactivateLayer(size_t idx) {
-        if (LayerIsActive(idx)) {
-            m_deferredToggleLayers.push_back({idx, DeferType::Deactivate});
-        }
+        m_deferredToggleLayers.push_back({idx, DeferType::Deactivate});
     }
 
     inline void ToggleLayer(size_t idx) {
-        if (LayerIsActive(idx)) {
-            DeactivateLayer(idx);
-        } else {
-            ActivateLayer(idx);
-        }
+        m_deferredToggleLayers.push_back({idx, DeferType::ToggleActive});
     }
 
     inline void AddUIElement(std::shared_ptr<UI::Element> element,

--- a/src/engine/Engine.hpp
+++ b/src/engine/Engine.hpp
@@ -46,29 +46,41 @@ public:
     }
 
     inline bool LayerIsActive(size_t idx) {
-        return m_activeLayers.find(idx) != m_activeLayers.end();
+        if (!m_layers.contains(idx)) {
+            return false;
+        }
+
+        if (m_activeLayers.find(idx) != m_activeLayers.end()) {
+            return true;
+        }
+
+        for (const auto &deferPair : m_deferredToggleLayers) {
+            if (deferPair.first == idx) {
+                return (deferPair.second == DeferType::Add ||
+                        deferPair.second == DeferType::Activate);
+            }
+        }
+
+        return false;
     }
 
     inline void ActivateLayer(size_t idx) {
-        if (m_layers.find(idx) != m_layers.end() &&
-            !(m_activeLayers.find(idx) != m_activeLayers.end())) {
+        if (!LayerIsActive(idx)) {
             m_deferredToggleLayers.push_back({idx, DeferType::Activate});
         }
     }
 
     inline void DeactivateLayer(size_t idx) {
-        if (m_activeLayers.find(idx) != m_activeLayers.end()) {
+        if (LayerIsActive(idx)) {
             m_deferredToggleLayers.push_back({idx, DeferType::Deactivate});
         }
     }
 
     inline void ToggleLayer(size_t idx) {
-        if (m_layers.find(idx) != m_layers.end()) {
-            if (LayerIsActive(idx)) {
-                DeactivateLayer(idx);
-            } else {
-                ActivateLayer(idx);
-            }
+        if (LayerIsActive(idx)) {
+            DeactivateLayer(idx);
+        } else {
+            ActivateLayer(idx);
         }
     }
 


### PR DESCRIPTION
This PR adds support for deferred toggling of active layers until the end of each frame. The reason this is needed is because during click event handling, active layers might be desired to be toggled (using `ToggleLayer()`, `ActivateLayer()` or `DeactivateLayer()`) which leads to the iterator being "out of touch" and might end up in a segfault when indexing `m_layer` and accessing `->OnClick()`.

https://github.com/joelsiks/admirals/blob/781d619ba07acad5afe82dc4623f29f09f9f09ec/src/engine/Engine.cpp#L66-L68

A simple solution to this would indeed be to just add a check for a null pointer, however, to handle this correctly I've instead added support for deferring any such events until the end of each frame.

Additionally, this PR also fixes a segfault that would occur if adding a layer to the engine after the game loop has been started. This fix resizes the `layers` array defined above the game loop so that it can be index correctly.

Fixes #124 