### PR TITLE
Fixed bases not attacking nearby enemy ships

### DIFF
--- a/src/mvp/CommonTypes.hpp
+++ b/src/mvp/CommonTypes.hpp
@@ -89,8 +89,9 @@ inline std::map<uint8_t, ShipInfo> ShipInfoMap = {
 struct ShipData {
     ShipData() {}
     ShipData(uint16_t id, uint8_t type, uint8_t x, uint8_t y, uint16_t health,
-             uint8_t owner)
-        : id(id), type(type), location({x, y}), health(health), owner(owner) {}
+             uint8_t owner, uint8_t action = ShipAction::None)
+        : id(id), type(type), location({x, y}), health(health), owner(owner),
+          action(action) {}
 
     uint16_t id = 0;
     uint16_t lastActionTurn = 0;

--- a/src/mvp/MvpServer.cpp
+++ b/src/mvp/MvpServer.cpp
@@ -166,16 +166,18 @@ void MvpServer::StartGame() {
     // Add top player base
     const ShipData baseTop =
         ShipData(m_shipID++, ShipType::Base, baseData.TopSpawns[0].x,
-                 baseData.TopSpawns[0].y, baseData.Health, m_playerTop.id);
+                 baseData.TopSpawns[0].y, baseData.Health, m_playerTop.id,
+                 ShipAction::Attack);
     m_playerTop.baseId = baseTop.id;
     m_playerTop.ships[baseTop.id] = baseTop;
     m_playerTop.numShips++;
     m_board[baseData.TopSpawns[0].x][baseData.TopSpawns[0].y] = baseTop.id;
 
     // Add bottom player base
-    const ShipData baseBottom = ShipData(
-        m_shipID++, ShipType::Base, baseData.BottomSpawns[0].x,
-        baseData.BottomSpawns[0].y, baseData.Health, m_playerBottom.id);
+    const ShipData baseBottom =
+        ShipData(m_shipID++, ShipType::Base, baseData.BottomSpawns[0].x,
+                 baseData.BottomSpawns[0].y, baseData.Health, m_playerBottom.id,
+                 ShipAction::Attack);
     m_playerBottom.baseId = baseBottom.id;
     m_playerBottom.ships[baseBottom.id] = baseBottom;
     m_playerBottom.numShips++;


### PR DESCRIPTION
The improved ship combat changes prevented bases from attacking since their default action was never changed from None.

Fixes #132 