### PR TITLE
Connect to a custom IP

### DIFF
--- a/src/engine/UI/menu/MenuOption.cpp
+++ b/src/engine/UI/menu/MenuOption.cpp
@@ -153,8 +153,6 @@ void InputOption::OnHidden() {
     }
 }
 
-void InputOption::SetOptionText(const std::string &text) { m_text = text; }
-
 std::string InputOption::GetOptionText() const {
     if (m_text.length() == 0) {
         return m_placeholderText;

--- a/src/engine/UI/menu/MenuOption.cpp
+++ b/src/engine/UI/menu/MenuOption.cpp
@@ -153,6 +153,8 @@ void InputOption::OnHidden() {
     }
 }
 
+void InputOption::SetOptionText(const std::string &text) { m_text = text; }
+
 std::string InputOption::GetOptionText() const {
     if (m_text.length() == 0) {
         return m_placeholderText;

--- a/src/engine/UI/menu/MenuOption.hpp
+++ b/src/engine/UI/menu/MenuOption.hpp
@@ -113,7 +113,6 @@ public:
 
     virtual void OnHidden() override;
 
-    void SetOptionText(const std::string &text);
     std::string GetOptionText() const override;
 
     inline bool IsActive() const { return m_isActive; }
@@ -121,6 +120,7 @@ public:
 
     void HandleKeyPressEvent(void *sender, events::KeyPressEventArgs &args);
 
+    inline void SetInputText(const std::string &text) { m_text = text; }
     inline std::string GetInputText() const { return m_text; }
 
 private:

--- a/src/engine/UI/menu/MenuOption.hpp
+++ b/src/engine/UI/menu/MenuOption.hpp
@@ -113,6 +113,7 @@ public:
 
     virtual void OnHidden() override;
 
+    void SetOptionText(const std::string &text);
     std::string GetOptionText() const override;
 
     inline bool IsActive() const { return m_isActive; }

--- a/src/mvp/GameData.hpp
+++ b/src/mvp/GameData.hpp
@@ -22,6 +22,7 @@ public:
 
     static constexpr size_t StartMenuIdx = 0;
     static constexpr size_t GameUIIdx = 1;
+    static constexpr size_t ConnectMenuIdx = 2;
 
     inline static std::shared_ptr<objects::SelectionManager> Selection;
     inline static Vector2 MousePosition;

--- a/src/mvp/main.cpp
+++ b/src/mvp/main.cpp
@@ -176,8 +176,7 @@ void CreateStartMenuScene(const Texture &atlas) {
 void CreateConnectMenu(const std::shared_ptr<GameManager> &gameManager) {
     auto connectMenu = std::make_shared<UI::menu::Menu>(
         "Enter the IP of the server", Color::BLACK,
-        Color::FromRGBA(40, 40, 40, 200),
-        GameData::engine->GetWindowSize().y() / 3.0);
+        Color::FromRGBA(20, 20, 20, 140), 100);
     GameData::engine->AddLayer(GameData::ConnectMenuIdx, connectMenu, false);
 
     const auto inputOption = std::make_shared<UI::menu::InputOption>(
@@ -186,7 +185,7 @@ void CreateConnectMenu(const std::shared_ptr<GameManager> &gameManager) {
         [inputOption](void *, events::MouseClickEventArgs &args) {
             if (args.pressed && args.button == events::MouseButton::Left &&
                 !inputOption->IsActive()) {
-                inputOption->SetOptionText("");
+                inputOption->SetInputText("");
             }
         });
 

--- a/src/mvp/objects/GameManager.cpp
+++ b/src/mvp/objects/GameManager.cpp
@@ -167,6 +167,7 @@ void GameManager::ResetState(bool removeConnection) {
     GameData::Selection->Clear();
 
     if (removeConnection) {
+        m_networkManager->StopServer();
         GameData::engine->GetScene()->RemoveDisplayable("networkManager");
         m_networkManager = GameData::engine->MakeGameObject<NetworkManager>(
             "networkManager", (*this));

--- a/src/mvp/objects/NetworkManager.cpp
+++ b/src/mvp/objects/NetworkManager.cpp
@@ -9,12 +9,7 @@ NetworkManager::NetworkManager(const std::string &name,
                                GameManager &gameManager)
     : GameObject(name), m_gameManager(gameManager) {}
 
-NetworkManager::~NetworkManager() {
-    if (m_isHost) {
-        m_stopServer = true;
-        m_serverThread.join();
-    }
-}
+NetworkManager::~NetworkManager() { StopServer(); }
 
 void NetworkManager::OnStart(const EngineContext &) {}
 
@@ -59,6 +54,17 @@ bool NetworkManager::ConnectToServer(const std::string &ip, uint16_t port,
     }
 
     return false;
+}
+
+void NetworkManager::StopServer() {
+    if (!m_isHost || m_stopServer) {
+        return;
+    }
+    if (m_debug) {
+        printf("Stopping server\n");
+    }
+    m_stopServer = true;
+    m_serverThread.join();
 }
 
 void NetworkManager::BuyShip(uint8_t type) {

--- a/src/mvp/objects/NetworkManager.hpp
+++ b/src/mvp/objects/NetworkManager.hpp
@@ -18,8 +18,8 @@ public:
     void Render(const EngineContext &ctx) const override {}
 
     bool StartAndConnectToServer(uint16_t port, size_t maxTries);
-
     bool ConnectToServer(const std::string &ip, uint16_t port, size_t maxTries);
+    void StopServer();
 
     void BuyShip(uint8_t type);
     void MoveShip(uint16_t id, uint8_t x, uint8_t y);


### PR DESCRIPTION
Adds a menu when clicking "Connect to server" which has a field to set a new IP. `127.0.0.1` is pre-set and is cleared if a user wants to enter their own.


Also fixed an issue where the server would not close when destroying the network manager (probably related to the deferred delete keeping the object alive for longer, but not sure) 