### PR TITLE
Layer switch hovering effects fix

### DIFF
--- a/src/engine/DeferedAction.hpp
+++ b/src/engine/DeferedAction.hpp
@@ -9,6 +9,7 @@ enum DeferType {
     Activate,
     Deactivate,
     ToggleActive,
+    MouseMove,
 };
 
 } // namespace admirals

--- a/src/engine/IDisplayLayer.cpp
+++ b/src/engine/IDisplayLayer.cpp
@@ -20,9 +20,6 @@ void IDisplayLayer::OnClick(events::MouseClickEventArgs &args) {
 }
 
 void IDisplayLayer::OnMouseMove(events::MouseMotionEventArgs &args) {
-    // TODO: This currently handles MouseEnter/MouseMove before any MouseLeave
-    // events, which is reverse of what is happening chronologically. Instead,
-    // one might want to handle MouseLeave events first.
     const Vector2 mouseLocation = args.Location();
     std::unordered_set<std::string> currentMouseOverElements;
 
@@ -36,11 +33,6 @@ void IDisplayLayer::OnMouseMove(events::MouseMotionEventArgs &args) {
         if (displayable->IsVisible() &&
             displayable->GetBoundingBox().Contains(mouseLocation)) {
             currentMouseOverElements.insert(identifier);
-            if (m_mouseOverSet.insert(identifier).second) {
-                displayable->OnMouseEnter(args);
-            } else {
-                displayable->OnMouseMove(args);
-            }
         }
     }
 
@@ -59,6 +51,19 @@ void IDisplayLayer::OnMouseMove(events::MouseMotionEventArgs &args) {
             it = m_mouseOverSet.erase(it);
         } else {
             it++;
+        }
+    }
+
+    for (const std::string &identifier : currentMouseOverElements) {
+        auto el = m_displayables.Find(identifier);
+        if (el == nullptr) {
+            continue;
+        }
+
+        if (m_mouseOverSet.insert(identifier).second) {
+            el->OnMouseEnter(args);
+        } else {
+            el->OnMouseMove(args);
         }
     }
 }

--- a/src/engine/UI/Button.cpp
+++ b/src/engine/UI/Button.cpp
@@ -34,6 +34,7 @@ void Button::OnMouseLeave(events::MouseMotionEventArgs &) {
 }
 
 void Button::OnMouseMove(events::MouseMotionEventArgs &) {
+    m_shouldFadeBackground = true;
     renderer::Renderer::SetCursor(renderer::Cursor::Hand);
 }
 

--- a/src/engine/UI/menu/Menu.cpp
+++ b/src/engine/UI/menu/Menu.cpp
@@ -18,11 +18,47 @@ Menu::Menu(const std::string &menuTitle, const Color &foregroundColor,
 }
 
 void Menu::Render(const EngineContext &ctx) const {
-    float centerPositionOffset = m_topPadding;
-
     // Draw background.
     renderer::Renderer::DrawRectangle(Vector2(0, 0), ctx.windowSize, m_bgColor);
 
+    for (auto it = m_displayables.rbegin(); it != m_displayables.rend(); ++it) {
+        if (*it == nullptr) {
+            continue;
+        }
+
+        auto element = std::dynamic_pointer_cast<UI::Element>(*it);
+        auto option = std::dynamic_pointer_cast<menu::MenuOption>(element);
+
+        const Vector2 position = option->GetPosition();
+        const Vector2 displaySize = option->GetSize();
+
+        option->Render(ctx);
+
+        // If we're rendering the menu title, add a line below it.
+        if (option->identifier() == MENU_TITLE_NAME) {
+            renderer::Renderer::DrawLine(
+                Vector2(position[0], position[1] + displaySize[1]),
+                Vector2(position[0] + displaySize[0],
+                        position[1] + displaySize[1]),
+                m_fgColor);
+        }
+
+        // If debugging, render an outline around the UI Element.
+        if (ctx.debug) {
+            renderer::Renderer::DrawRectangleOutline(position, displaySize, 2,
+                                                     Color::RED);
+        }
+    }
+
+    if (ctx.debug) {
+        m_quadtree.DrawTree();
+    }
+}
+
+void Menu::Update(const EngineContext &ctx) {
+    IDisplayLayer::Update(ctx);
+
+    float centerPositionOffset = m_topPadding;
     for (auto it = m_displayables.rbegin(); it != m_displayables.rend(); ++it) {
         if (*it == nullptr) {
             continue;
@@ -36,6 +72,11 @@ void Menu::Render(const EngineContext &ctx) const {
         // orientation, even if it is changed externally.
         option->SetDisplayOrientation(DisplayOrientation::Center);
 
+        // Update menu-dependent state of the options.
+        option->SetSize(renderer::Renderer::TextFontSize(
+            option->GetOptionText(), ctx.fontWidth, ctx.fontHeight));
+        option->SetTextColor(m_fgColor);
+
         const DisplayOrientation orientation = option->GetDisplayOrientation();
         Vector2 displaySize = option->GetSize();
 
@@ -44,39 +85,15 @@ void Menu::Render(const EngineContext &ctx) const {
             GetPositionFromOrientation(orientation, displaySize, ctx);
         position[1] += centerPositionOffset;
 
-        // Update menu-dependent state of the options.
-        option->SetSize(renderer::Renderer::TextFontSize(
-            option->GetOptionText(), ctx.fontWidth, ctx.fontHeight));
-        option->SetTextColor(m_fgColor);
-
         option->SetPosition(position);
-        option->Render(ctx);
 
         // If we're rendering the menu title, add a line below it.
         if (option->identifier() == MENU_TITLE_NAME) {
-            renderer::Renderer::DrawLine(
-                Vector2(position[0], position[1] + displaySize[1]),
-                Vector2(position[0] + displaySize[0],
-                        position[1] + displaySize[1]),
-                m_fgColor);
             centerPositionOffset += MENU_TITLE_LINE_OFFSET;
-        }
-
-        // If debugging, render an outline around the UI Element.
-        if (ctx.debug) {
-            renderer::Renderer::DrawRectangleOutline(position, displaySize, 2,
-                                                     Color::RED);
         }
 
         centerPositionOffset += displaySize[1];
     }
 
-    if (ctx.debug) {
-        m_quadtree.DrawTree();
-    }
-}
-
-void Menu::Update(const EngineContext &ctx) {
-    IDisplayLayer::Update(ctx);
     RebuildQuadTree(ctx.windowSize);
 }

--- a/src/engine/UI/menu/Menu.cpp
+++ b/src/engine/UI/menu/Menu.cpp
@@ -26,8 +26,8 @@ void Menu::Render(const EngineContext &ctx) const {
             continue;
         }
 
-        auto element = std::dynamic_pointer_cast<UI::Element>(*it);
-        auto option = std::dynamic_pointer_cast<menu::MenuOption>(element);
+        const auto option = std::dynamic_pointer_cast<menu::MenuOption>(*it);
+        if(option == nullptr) continue;
 
         const Vector2 position = option->GetPosition();
         const Vector2 displaySize = option->GetSize();
@@ -64,8 +64,8 @@ void Menu::Update(const EngineContext &ctx) {
             continue;
         }
 
-        auto element = std::dynamic_pointer_cast<UI::Element>(*it);
-        auto option = std::dynamic_pointer_cast<menu::MenuOption>(element);
+        auto option = std::dynamic_pointer_cast<menu::MenuOption>(*it);
+        if(option == nullptr) continue;
 
         // TODO: This should be fixed somewhere else in the future. This is
         // needed to make sure that all elements are displayed in a center

--- a/src/engine/UI/menu/MenuOption.cpp
+++ b/src/engine/UI/menu/MenuOption.cpp
@@ -32,6 +32,7 @@ void MenuOption::OnMouseLeave(events::MouseMotionEventArgs &) {
 }
 
 void MenuOption::OnMouseMove(events::MouseMotionEventArgs &) {
+    m_shouldDrawBackground = true;
     renderer::Renderer::SetCursor(renderer::Cursor::Hand);
 }
 


### PR DESCRIPTION
This PR solves issues related to switching active/inactive layers and mouse events. For example, if the mouse is on a menuoption when a menu is shown, appropriate hovering effects should now work.

MouseLeave events are now handled before MouseMove/MouseEnter, so that events are handled in the correct order. We also defer sending a MouseMove event to a newly activated layer so that the layer can update itself before it gets notified of the current mouse position and can handle any Move/Enter/Leave event accordingly.

Menu now also does all its updating in the Update method, not the Render method (haha).

Fixes #139 