### PR TITLE
Added engine debugMode and rendering displayPort

### DIFF
--- a/src/engine/DataObjects.hpp
+++ b/src/engine/DataObjects.hpp
@@ -2,8 +2,8 @@
 
 #include <VK2D/Texture.h>
 #include <cmath>
+#include <cstdint>
 #include <sstream>
-#include <stdint.h>
 #include <string>
 
 #undef TRANSPARENT

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -10,11 +10,14 @@ static const float FONT_CHAR_WIDTH = 16.0;
 static const float FONT_CHAR_HEIGHT = 36.0;
 
 Engine::Engine(const std::string &gameName, int windowWidth, int windowHeight,
-               bool debug)
+               uint32_t debugMode)
     : m_context() {
     m_context.windowSize = Vector2(static_cast<float>(windowWidth),
                                    static_cast<float>(windowHeight));
-    m_context.debug = debug;
+    // Default to the entire window size.
+    m_context.displayPort = Rect(0, m_context.windowSize);
+    m_context.debug = debugMode;
+
     m_renderer = std::make_shared<renderer::Renderer>(gameName, windowWidth,
                                                       windowHeight);
     // Initialize the renderer right after creating it. Necessary in cases where
@@ -22,8 +25,7 @@ Engine::Engine(const std::string &gameName, int windowWidth, int windowHeight,
     m_renderer->Init(m_context);
 
     m_context.fontTexture = new Texture(vk2dTextureLoad(FONT_PATH));
-    m_context.fontWidth = FONT_CHAR_WIDTH;
-    m_context.fontHeight = FONT_CHAR_HEIGHT;
+    m_context.fontSize = Vector2(FONT_CHAR_WIDTH, FONT_CHAR_HEIGHT);
 
     m_scene = std::make_shared<Scene>();
 }
@@ -90,6 +92,13 @@ bool Engine::PollAndHandleEvent() {
         case SDL_KEYUP: {
             auto args = KeyPressEventArgs(e.key);
             onKeyPress.Invoke(this, args);
+
+            if (args.key == SDLK_F12 && args.isKeyUp &&
+                Engine::HasDebugMask(m_context.debug,
+                                     EngineDebugMode::DebugToggleHotkey)) {
+                ToggleDebug();
+            }
+
         } break;
         default:
             break;

--- a/src/engine/EngineContext.hpp
+++ b/src/engine/EngineContext.hpp
@@ -7,13 +7,16 @@ namespace admirals {
 struct EngineContext {
     Vector2 windowSize;
 
+    // Represents thepartof the window that is used for displaying the game.
+    Rect displayPort;
+
     // Indicates whether to draw outlines of elements for debugging purposes.
-    bool debug;
+    uint32_t debug;
 
     double deltaTime;
 
     Texture *fontTexture;
-    float fontWidth, fontHeight;
+    Vector2 fontSize;
 };
 
 } // namespace admirals

--- a/src/engine/IDisplayLayer.cpp
+++ b/src/engine/IDisplayLayer.cpp
@@ -98,7 +98,7 @@ IDisplayLayer::FindDisplayable(const std::string &identifier) {
     return m_displayables.Find(identifier);
 }
 
-std::vector<std::string> IDisplayLayer::GetDisplayableNames() {
+std::vector<std::string> IDisplayLayer::GetDisplayableIdentifiers() {
     std::vector<std::string> vec = {};
     for (const auto &value : this->m_displayables) {
         vec.emplace_back(value->identifier());

--- a/src/engine/IDisplayLayer.hpp
+++ b/src/engine/IDisplayLayer.hpp
@@ -31,7 +31,7 @@ public:
     FindDisplayable(const std::string &identifier);
 
     inline size_t NumDisplayables() const { return m_displayables.Size(); }
-    std::vector<std::string> GetDisplayableNames();
+    std::vector<std::string> GetDisplayableIdentifiers();
 
     void RebuildQuadTree(const Vector2 &windowSize);
     inline const QuadTree &GetQuadTree() const { return m_quadtree; }

--- a/src/engine/IDisplayable.hpp
+++ b/src/engine/IDisplayable.hpp
@@ -17,7 +17,6 @@ public:
     }
 
     virtual inline Rect GetBoundingBox() const { return m_boundingBox; };
-    // virtual inline Rect &GetBoundingBox() { return m_boundingBox; };
 
     virtual inline Vector2 GetPosition() const {
         return m_boundingBox.Position();

--- a/src/engine/Renderer.cpp
+++ b/src/engine/Renderer.cpp
@@ -4,6 +4,7 @@
 #include <VK2D/Renderer.h>
 
 #include "DataObjects.hpp"
+#include "Engine.hpp"
 #include "Renderer.hpp"
 
 using namespace admirals;
@@ -42,8 +43,9 @@ Renderer::~Renderer() {
 int Renderer::Init(const EngineContext &ctx) {
     const VK2DRendererConfig config = {
         VK2D_MSAA_32X, VK2D_SCREEN_MODE_IMMEDIATE, VK2D_FILTER_TYPE_NEAREST};
-    VK2DStartupOptions options = {ctx.debug, ctx.debug, ctx.debug, "error.txt",
-                                  false};
+    const bool debug =
+        Engine::HasDebugMask(ctx.debug, EngineDebugMode::DebugEnabled);
+    VK2DStartupOptions options = {debug, debug, debug, "error.txt", false};
 
     const int code = vk2dRendererInit(this->m_window, config, &options);
     if (code < 0) {
@@ -74,7 +76,7 @@ void DrawDebugFpsInformation(const EngineContext &ctx) {
     Renderer::DrawText(*ctx.fontTexture, Vector2(0), Color::RED, fpsString);
 }
 
-void Renderer::Render(const EngineContext &context,
+void Renderer::Render(const EngineContext &ctx,
                       const DrawableLayers &drawables) {
     vk2dRendererStartFrame(Color::WHITE.Data());
     for (const auto &drawable : drawables) {
@@ -82,11 +84,13 @@ void Renderer::Render(const EngineContext &context,
             continue;
         }
 
-        drawable->Render(context);
+        drawable->Render(ctx);
     }
 
-    if (context.debug) {
-        DrawDebugFpsInformation(context);
+    if (Engine::HasDebugMask(ctx.debug, EngineDebugMode::DebugEnabled |
+                                            EngineDebugMode::DebugRendering)) {
+        Renderer::DrawRectangleOutline(ctx.displayPort, 3, Color::BLUE);
+        DrawDebugFpsInformation(ctx);
     }
 
     vk2dRendererEndFrame();

--- a/src/engine/Renderer.hpp
+++ b/src/engine/Renderer.hpp
@@ -31,7 +31,7 @@ public:
     ~Renderer();
 
     int Init(const EngineContext &ctx);
-    static void Render(const EngineContext &context,
+    static void Render(const EngineContext &ctx,
                        const DrawableLayers &drawables);
 
     Vector2 GetWindowSize() const;
@@ -64,9 +64,10 @@ public:
 
     static void SetCursor(Cursor cursor);
 
-    static inline Vector2 TextFontSize(const std::string &text, float width,
-                                       float height) {
-        return Vector2(static_cast<float>(text.length()) * width, height);
+    static inline Vector2 TextFontSize(const std::string &text,
+                                       const Vector2 &fontSize,
+                                       const Vector2 &scale = 1.f) {
+        return Vector2(static_cast<float>(text.length()), 1) * fontSize * scale;
     }
 
 private:

--- a/src/engine/Scene.cpp
+++ b/src/engine/Scene.cpp
@@ -1,4 +1,5 @@
 #include "Scene.hpp"
+#include "Engine.hpp"
 #include "IInteractiveDisplayable.hpp"
 #include "PathFinding.hpp"
 
@@ -10,7 +11,8 @@ void Scene::Render(const EngineContext &ctx) const {
         object->Render(ctx);
     }
 
-    if (ctx.debug) {
+    if (Engine::HasDebugMask(ctx.debug, EngineDebugMode::DebugEnabled |
+                                            EngineDebugMode::DebugQuadTree)) {
         m_quadtree.DrawTree();
     }
 }

--- a/src/engine/UI/Data.cpp
+++ b/src/engine/UI/Data.cpp
@@ -3,27 +3,27 @@
 using namespace admirals;
 
 Vector2 admirals::UI::GetPositionFromOrientation(DisplayOrientation orientation,
-                                                 const Vector2 &displaySize,
+                                                 const Vector2 &elementSize,
                                                  const EngineContext &ctx) {
     Vector2 position(0, 0);
 
     // Handle center.
     if (orientation == DisplayOrientation::Center) {
-        position[0] = (ctx.windowSize.x() - displaySize[0]) / 2.0f;
-        return position;
+        position[0] = (ctx.displayPort.Width() - elementSize[0]) / 2.0f;
+        return position + ctx.displayPort.Position();
     }
 
     // Fix right offset.
     if (orientation == DisplayOrientation::UpperRight ||
         orientation == DisplayOrientation::LowerRight) {
-        position[0] = ctx.windowSize.x() - displaySize[0];
+        position[0] = ctx.displayPort.Width() - elementSize[0];
     }
 
     // Fix lower offset.
     if (orientation == DisplayOrientation::LowerLeft ||
         orientation == DisplayOrientation::LowerRight) {
-        position[1] = ctx.windowSize.y() - displaySize[1];
+        position[1] = ctx.displayPort.Height() - elementSize[1];
     }
 
-    return position;
+    return position + ctx.displayPort.Position();
 }

--- a/src/engine/UI/DisplayLayout.cpp
+++ b/src/engine/UI/DisplayLayout.cpp
@@ -1,6 +1,7 @@
 
 #include "UI/DisplayLayout.hpp"
 #include "DisplayLayout.hpp"
+#include "Engine.hpp"
 #include "Renderer.hpp"
 #include "UI/Data.hpp"
 
@@ -8,43 +9,54 @@ using namespace admirals;
 using namespace admirals::UI;
 
 void DisplayLayout::Render(const EngineContext &ctx) const {
-    Vector4 positionOffsets = Vector4(0);
-
     for (const auto &displayable : m_displayables) {
-        auto element = std::dynamic_pointer_cast<UI::Element>(displayable);
-        const DisplayOrientation orientation = element->GetDisplayOrientation();
-        const Vector2 displaySize = element->GetSize();
-
-        // Calculate the position with respect to the matching positionOffset.
-        Vector2 position =
-            GetPositionFromOrientation(orientation, displaySize, ctx);
-        position[0] += positionOffsets[static_cast<int>(orientation)];
-
-        element->SetPosition(position);
-
-        element->Render(ctx);
+        displayable->Render(ctx);
 
         // If debugging, render an outline around the UI Element.
-        if (ctx.debug) {
-            renderer::Renderer::DrawRectangleOutline(position, displaySize, 2,
+        if (Engine::HasDebugMask(ctx.debug,
+                                 EngineDebugMode::DebugEnabled |
+                                     EngineDebugMode::DebugRendering)) {
+            renderer::Renderer::DrawRectangleOutline(displayable->GetPosition(),
+                                                     displayable->GetSize(), 2,
                                                      Color::RED);
-        }
-
-        // Update the matching positionOffset.
-        if (orientation == DisplayOrientation::UpperRight ||
-            orientation == DisplayOrientation::LowerRight) {
-            positionOffsets[static_cast<int>(orientation)] -= displaySize[0];
-        } else {
-            positionOffsets[static_cast<int>(orientation)] += displaySize[0];
         }
     }
 
-    if (ctx.debug) {
+    if (Engine::HasDebugMask(ctx.debug, EngineDebugMode::DebugEnabled |
+                                            EngineDebugMode::DebugQuadTree)) {
         m_quadtree.DrawTree();
     }
 }
 
 void DisplayLayout::Update(const EngineContext &ctx) {
     IDisplayLayer::Update(ctx);
+
+    Vector4 positionOffsets = Vector4(0);
+
+    for (const auto &displayable : m_displayables) {
+        auto element = std::dynamic_pointer_cast<UI::Element>(displayable);
+        if (element == nullptr) {
+            continue;
+        }
+
+        const DisplayOrientation orientation = element->GetDisplayOrientation();
+        const Vector2 elementSize = element->GetSize();
+
+        // Calculate the position with respect to the matching positionOffset.
+        Vector2 position =
+            GetPositionFromOrientation(orientation, elementSize, ctx);
+        position[0] += positionOffsets[static_cast<int>(orientation)];
+
+        element->SetPosition(position);
+
+        // Update the matching positionOffset.
+        if (orientation == DisplayOrientation::UpperRight ||
+            orientation == DisplayOrientation::LowerRight) {
+            positionOffsets[static_cast<int>(orientation)] -= elementSize[0];
+        } else {
+            positionOffsets[static_cast<int>(orientation)] += elementSize[0];
+        }
+    }
+
     RebuildQuadTree(ctx.windowSize);
 }

--- a/src/engine/UI/TextElement.hpp
+++ b/src/engine/UI/TextElement.hpp
@@ -10,6 +10,7 @@ public:
                 const Vector2 &size, const Color &color);
 
     void SetText(const std::string &text);
+    std::string GetText() const { return m_text; }
 
     void Render(const EngineContext &ctx) const override;
 

--- a/src/engine/UI/menu/Menu.cpp
+++ b/src/engine/UI/menu/Menu.cpp
@@ -1,5 +1,6 @@
 #include "UI/menu/Menu.hpp"
 
+#include "Engine.hpp"
 #include "Renderer.hpp"
 #include "UI/Data.hpp"
 
@@ -46,13 +47,16 @@ void Menu::Render(const EngineContext &ctx) const {
         }
 
         // If debugging, render an outline around the UI Element.
-        if (ctx.debug) {
+        if (Engine::HasDebugMask(ctx.debug,
+                                 EngineDebugMode::DebugEnabled |
+                                     EngineDebugMode::DebugRendering)) {
             renderer::Renderer::DrawRectangleOutline(position, displaySize, 2,
                                                      Color::RED);
         }
     }
 
-    if (ctx.debug) {
+    if (Engine::HasDebugMask(ctx.debug, EngineDebugMode::DebugEnabled |
+                                            EngineDebugMode::DebugQuadTree)) {
         m_quadtree.DrawTree();
     }
 }
@@ -78,7 +82,7 @@ void Menu::Update(const EngineContext &ctx) {
 
         // Update menu-dependent state of the options.
         option->SetSize(renderer::Renderer::TextFontSize(
-            option->GetOptionText(), ctx.fontWidth, ctx.fontHeight));
+            option->GetOptionText(), ctx.fontSize));
         option->SetTextColor(m_fgColor);
 
         const DisplayOrientation orientation = option->GetDisplayOrientation();

--- a/src/engine/events/KeyPressEvent.hpp
+++ b/src/engine/events/KeyPressEvent.hpp
@@ -12,7 +12,7 @@ namespace admirals::events {
 class KeyPressEventArgs : public EventArgs {
 public:
     KeyPressEventArgs(const SDL_KeyboardEvent &e)
-        : key(e.keysym.sym), isKeyUp(e.state == SDL_PRESSED) {}
+        : key(e.keysym.sym), isKeyUp(e.state == SDL_RELEASED) {}
 
     const SDL_Keycode key; // The key that is pressed
     const bool isKeyUp;

--- a/src/mvp/CommonTypes.hpp
+++ b/src/mvp/CommonTypes.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
+#include <cstdint>
 #include <map>
-#include <stdint.h>
 #include <vector>
 
 namespace admirals::mvp {

--- a/src/mvp/main.cpp
+++ b/src/mvp/main.cpp
@@ -15,6 +15,7 @@
 #include "objects/SelectionManager.hpp"
 #include "objects/Ship.hpp"
 #include "objects/TreasureIsland.hpp"
+#include "objects/UIManager.hpp"
 
 // Undefine macro from msys
 #undef TRANSPARENT
@@ -84,6 +85,9 @@ void CreateGameUI(const Texture &atlas,
         "coinText", 0, "Coins: 0", Vector2(100, 20), Color::WHITE);
     gameManager->onCoinsChanged.Subscribe([coinText](void *, auto e) {
         coinText->SetText("Coins: " + std::to_string(e.coins));
+        auto ctx = GameData::engine->GetContext();
+        admirals::renderer::Renderer::TextFontSize(coinText->GetText(),
+                                                   ctx.fontSize);
     });
     gameUI->AddDisplayable(coinText);
 
@@ -152,6 +156,8 @@ void CreateStartMenu(const std::shared_ptr<GameManager> &gameManager) {
 void CreateStartMenuScene(const Texture &atlas) {
     auto startMenuScene = std::make_shared<Scene>();
 
+    startMenuScene->AddDisplayable(std::make_shared<UIManager>("uiManager"));
+
     startMenuScene->AddDisplayable(
         std::make_shared<Background>("background", blue, blue));
 
@@ -215,8 +221,11 @@ void CreateConnectMenu(const std::shared_ptr<GameManager> &gameManager) {
 }
 
 int main(int, char *[]) {
-    GameData::engine =
-        std::make_unique<Engine>("Admirals", GridWidth, GridHeight, false);
+    GameData::engine = std::make_unique<Engine>(
+        "Admirals", GridWidth, GridHeight,
+        EngineDebugMode::DebugDisabled | EngineDebugMode::DebugToggleHotkey |
+            EngineDebugMode::DebugPathfinding |
+            EngineDebugMode::DebugRendering);
 
     const Texture atlas =
         Texture::LoadFromPath("assets/admirals_texture_atlas.png");
@@ -225,6 +234,7 @@ int main(int, char *[]) {
     GameData::Selection =
         GameData::engine->MakeGameObject<SelectionManager>("selectionMananger");
     GameData::Animator = GameData::engine->MakeGameObject<Animator>("animator");
+    GameData::engine->MakeGameObject<UIManager>("uiManager");
 
     CreateGameBoard(atlas);
     CreateGameUI(atlas, gameManager);

--- a/src/mvp/objects/Ship.cpp
+++ b/src/mvp/objects/Ship.cpp
@@ -1,4 +1,5 @@
 #include "objects/Ship.hpp"
+#include "Engine.hpp"
 #include "GameData.hpp"
 #include "PathFinding.hpp"
 #include "Ship.hpp"
@@ -201,7 +202,9 @@ void Ship::Render(const EngineContext &ctx) const {
     DrawHealthBar(bounds);
     DrawOutline(bounds);
     DrawNavPath(bounds, ctx.windowSize);
-    if (ctx.debug) {
+    if (Engine::HasDebugMask(ctx.debug,
+                             EngineDebugMode::DebugEnabled |
+                                 EngineDebugMode::DebugPathfinding)) {
         DrawNavMeshInfo(*ctx.fontTexture);
     }
 }

--- a/src/mvp/objects/UIManager.hpp
+++ b/src/mvp/objects/UIManager.hpp
@@ -1,0 +1,37 @@
+#include "GameData.hpp"
+#include "GameObject.hpp"
+#include "UI/TextElement.hpp"
+#include "UI/menu/Menu.hpp"
+#include "objects/GridObject.hpp"
+
+namespace admirals::mvp::objects {
+
+class UIManager : public GameObject {
+    using GameObject::GameObject; // Inherit constructors
+public:
+    inline void OnUpdate(const EngineContext &) override {
+        const auto topLeft =
+            GridObject::ConvertPositionGridToWorld(Vector2(0, -1));
+        const auto bottomRight = GridObject::ConvertPositionGridToWorld(
+            Vector2(GameData::GridCells, GameData::GridCells + 1));
+        GameData::engine->SetDisplayPort({topLeft, bottomRight - topLeft});
+
+        /*
+        for(const auto index : GameData::engine->GetActiveLayersIndices()) {
+            const auto layer = GameData::engine->GetLayer(index);
+            for(const auto identifier : layer->GetDisplayableIdentifiers()){
+                const auto displayable = layer->FindDisplayable(identifier);
+                if (displayable == nullptr) {
+                    continue;
+                }
+                // TODO: Rescale
+                displayable->SetSize(displayable->GetSize());
+            }
+        }
+        */
+    }
+
+    void Render(const EngineContext &ctx) const override {}
+};
+
+} // namespace admirals::mvp::objects

--- a/src/test/NetworkTestData.hpp
+++ b/src/test/NetworkTestData.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <stdint.h>
+#include <cstdint>
 
 struct TestEnum {
     static const uint32_t GAME_START = 0;

--- a/src/test/gameObject.test.cpp
+++ b/src/test/gameObject.test.cpp
@@ -151,7 +151,8 @@ private:
 };
 
 int main(int, char *[]) {
-    Engine engine("GameObject Test", WINDOW_WIDTH, WINDOW_HEIGHT, false);
+    Engine engine("GameObject Test", WINDOW_WIDTH, WINDOW_HEIGHT,
+                  EngineDebugMode::DebugAll);
     engine.AddGameObject(
         std::make_shared<CellObject>("1", Vector3(0, 0, 2), Color::BLUE));
     engine.AddGameObject(

--- a/src/test/ui.test.cpp
+++ b/src/test/ui.test.cpp
@@ -54,8 +54,7 @@ private:
     bool m_keepAspectRatio;
 };
 
-std::shared_ptr<menu::Menu> CreateEscapeMenu(Engine &engine,
-                                             bool initialDebugValue) {
+std::shared_ptr<menu::Menu> CreateEscapeMenu(Engine &engine) {
     auto escapeMenu = std::make_shared<menu::Menu>(
         "Pause Menu", Color::BLACK, Color::FromRGBA(50, 50, 50, 100));
 
@@ -79,13 +78,13 @@ std::shared_ptr<menu::Menu> CreateEscapeMenu(Engine &engine,
 
     const auto toggleDebugOption = std::make_shared<menu::ToggleOption>(
         "toggleDebugRenderingOption", 1.0, "Debug Rendering",
-        initialDebugValue);
+        engine.GetContext().debug & EngineDebugMode::DebugEnabled != 0);
     toggleDebugOption->onClick.Subscribe(
         [&engine](void *, events::MouseClickEventArgs &args) {
             if (args.pressed)
                 return;
 
-            engine.ToggleDebugRendering();
+            engine.ToggleDebug();
         });
     escapeMenu->AddDisplayable(toggleDebugOption);
 
@@ -143,13 +142,13 @@ CreateTestUI(std::shared_ptr<TextureObject> textureObj) {
 
 int main(int, char **) {
 
-    const bool debug = true;
-    Engine engine("UI Test", WINDOW_WIDTH, WINDOW_HEIGHT, debug);
+    Engine engine("UI Test", WINDOW_WIDTH, WINDOW_HEIGHT,
+                  EngineDebugMode::DebugAll);
 
     const size_t escapeMenuIdx = 0;
     const size_t testUIIdx = 1;
 
-    auto escapeMenu = CreateEscapeMenu(engine, debug);
+    auto escapeMenu = CreateEscapeMenu(engine);
     engine.AddLayer(escapeMenuIdx,
                     std::dynamic_pointer_cast<IDisplayLayer>(escapeMenu),
                     false);


### PR DESCRIPTION
Me and @JoXW100 have implemented more control over setting/toggling specific debug features, now you can also use `F12` when `EngineDebugMode::DebugToggleHotkey` to toggle debug globally.

We've also implemented a fix for different UI displayPorts so that scaling is done correctly.

There are also some small fixes: moving from including `stdint.h` (C-header) to `cstdint` (C++-header), added a getter for `TextElement`'s text and renaming from names to identifier for consistency.

Fixes #143
Fixes #144