### PR TITLE
Various MVP connection fixes

### DIFF
--- a/src/mvp/MvpServer.cpp
+++ b/src/mvp/MvpServer.cpp
@@ -14,12 +14,10 @@ void MvpServer::OnClientDisconnect(const std::shared_ptr<Connection> &client) {
     if (client->GetID() == m_playerTop.id) {
         m_playerTop.ready = false;
         m_playerTop.connected = false;
-        m_playerTop.id = 0;
         m_connectedPlayers--;
     } else if (client->GetID() == m_playerBottom.id) {
         m_playerBottom.ready = false;
         m_playerBottom.connected = false;
-        m_playerBottom.id = 0;
         m_connectedPlayers--;
     }
 

--- a/src/mvp/objects/GameManager.cpp
+++ b/src/mvp/objects/GameManager.cpp
@@ -138,8 +138,8 @@ void GameManager::UpdateBoard(int turn, int coins,
 }
 
 void GameManager::PlayAgain() {
-    ResetState(false);
     m_menuManager->ToggleEndGameMenu();
+    ResetState(false);
     ReadyUp();
 }
 
@@ -168,6 +168,7 @@ void GameManager::ResetState(bool removeConnection) {
 
     if (removeConnection) {
         m_networkManager->StopServer();
+        m_networkManager->Disconnect();
         GameData::engine->GetScene()->RemoveDisplayable("networkManager");
         m_networkManager = GameData::engine->MakeGameObject<NetworkManager>(
             "networkManager", (*this));

--- a/src/mvp/objects/MenuManager.cpp
+++ b/src/mvp/objects/MenuManager.cpp
@@ -87,7 +87,11 @@ void MenuManager::ToggleOpponentDisconnectMenu() {
 }
 
 void MenuManager::ToggleServerDisconnectMenu() {
-    GameData::engine->ToggleLayer(GameData::GameUIIdx);
+    if (GameData::engine->LayerIsActive(m_opponentDisconnectIdx)) {
+        GameData::engine->ToggleLayer(m_opponentDisconnectIdx);
+    } else {
+        GameData::engine->ToggleLayer(GameData::GameUIIdx);
+    }
     GameData::engine->ToggleLayer(m_serverDisconnectIdx);
 }
 

--- a/src/mvp/objects/NetworkManager.cpp
+++ b/src/mvp/objects/NetworkManager.cpp
@@ -109,9 +109,7 @@ void NetworkManager::ReadyUp() {
 
 void NetworkManager::HandleMessages() {
     if (!IsConnected()) {
-        if (m_gameManager.GameStarted()) {
-            m_gameManager.AbortGame();
-        }
+        m_gameManager.AbortGame();
         return;
     }
 


### PR DESCRIPTION
I went through the MVP and found a few issues related to connections/communication that have now been fixed. These were:

- Client would not be notified that the server had closed when initially waiting for an opponent
- Client would not be notified that the server had closed when waiting for opponent to reconnect
- Deferred actions kept the server connection alive for longer, meaning the client would not truly disconnect
- Transfer of ship ownership after a client reconnected would not happen correctly


Please feel free to also test for yourself and see if you can find any more issues