### PR TITLE
MVP Help menu

### DIFF
--- a/src/engine/UI/menu/Menu.hpp
+++ b/src/engine/UI/menu/Menu.hpp
@@ -24,7 +24,7 @@ public:
     }
 
     // TODO: This should probably be handled some other way..
-    static constexpr float commonDepthOrder = 10;
+    static constexpr float commonDepthOrder = 20;
 
 private:
     std::shared_ptr<TextOption> m_titleOption;

--- a/src/mvp/GameData.hpp
+++ b/src/mvp/GameData.hpp
@@ -24,6 +24,7 @@ public:
     static constexpr size_t StartMenuIdx = 0;
     static constexpr size_t GameUIIdx = 1;
     static constexpr size_t ConnectMenuIdx = 2;
+    static constexpr size_t HelpMenuIdx = 3;
 
     inline static std::shared_ptr<objects::SelectionManager> Selection;
     inline static std::shared_ptr<objects::Animator> Animator;

--- a/src/mvp/main.cpp
+++ b/src/mvp/main.cpp
@@ -139,6 +139,7 @@ void CreateStartMenu(const std::shared_ptr<GameManager> &gameManager) {
     helpOption->onClick.Subscribe(
         [gameManager](void *, events::MouseClickEventArgs &args) {
             if (args.pressed && args.button == events::MouseButton::Left) {
+                args.handled = true;
                 ToggleHelpMenu();
             }
         });
@@ -149,6 +150,7 @@ void CreateStartMenu(const std::shared_ptr<GameManager> &gameManager) {
     connectOption->onClick.Subscribe(
         [gameManager](void *, events::MouseClickEventArgs &args) {
             if (args.pressed && args.button == events::MouseButton::Left) {
+                args.handled = true;
                 ToggleConnectMenu();
             }
         });
@@ -237,7 +239,7 @@ void CreateConnectMenu(const std::shared_ptr<GameManager> &gameManager) {
 
 void CreateHelpMenu() {
     auto helpMenu = std::make_shared<UI::menu::Menu>(
-        "Welcome to admirals conquest!", Color::BLACK,
+        "Welcome to Admirals Conquest!", Color::BLACK,
         Color::FromRGBA(70, 70, 70, 140), 100);
     GameData::engine->AddLayer(GameData::HelpMenuIdx, helpMenu, false);
 
@@ -246,7 +248,7 @@ void CreateHelpMenu() {
         "Spend gold to buy ships.",
         "Buy ships by clicking the ship icons.",
         "Gold generates passively.",
-        "Place ships by islands for bonus gold.",
+        "Place ships by islands for bonus gold.\ntest123",
         "Select ships by clicking on them.",
         "You can also drag to select multiple.",
         "Click on the grid to move ships.",

--- a/src/mvp/main.cpp
+++ b/src/mvp/main.cpp
@@ -246,7 +246,7 @@ void CreateHelpMenu() {
         "Spend gold to buy ships.",
         "Buy ships by clicking the ship icons.",
         "Gold generates passively.",
-        "Islands give extra gold.",
+        "Place ships by islands for bonus gold.",
         "Select ships by clicking on them.",
         "You can also drag to select multiple.",
         "Click on the grid to move ships.",

--- a/src/mvp/main.cpp
+++ b/src/mvp/main.cpp
@@ -248,7 +248,7 @@ void CreateHelpMenu() {
         "Spend gold to buy ships.",
         "Buy ships by clicking the ship icons.",
         "Gold generates passively.",
-        "Place ships by islands for bonus gold.\ntest123",
+        "Place ships by islands for bonus gold.",
         "Select ships by clicking on them.",
         "You can also drag to select multiple.",
         "Click on the grid to move ships.",

--- a/src/mvp/main.cpp
+++ b/src/mvp/main.cpp
@@ -238,7 +238,7 @@ void CreateConnectMenu(const std::shared_ptr<GameManager> &gameManager) {
 void CreateHelpMenu() {
     auto helpMenu = std::make_shared<UI::menu::Menu>(
         "Welcome to admirals conquest!", Color::BLACK,
-        Color::FromRGBA(20, 20, 20, 140), 100);
+        Color::FromRGBA(70, 70, 70, 140), 100);
     GameData::engine->AddLayer(GameData::HelpMenuIdx, helpMenu, false);
 
     std::vector<std::string> sentences = {

--- a/src/mvp/main.cpp
+++ b/src/mvp/main.cpp
@@ -44,6 +44,11 @@ void ToggleConnectMenu() {
     GameData::engine->ToggleLayer(GameData::ConnectMenuIdx);
 }
 
+void ToggleHelpMenu() {
+    GameData::engine->ToggleLayer(GameData::StartMenuIdx);
+    GameData::engine->ToggleLayer(GameData::HelpMenuIdx);
+}
+
 void CreateGameBoard(const Texture &atlas) {
     GameData::engine->MakeGameObject<Background>("background", blue,
                                                  Color::BLACK);
@@ -128,6 +133,16 @@ void CreateStartMenu(const std::shared_ptr<GameManager> &gameManager) {
             }
         });
     startMenu->AddDisplayable(exitOption);
+
+    auto helpOption = std::make_shared<UI::menu::ClickOption>("helpOption", 1.0,
+                                                              "How to play");
+    helpOption->onClick.Subscribe(
+        [gameManager](void *, events::MouseClickEventArgs &args) {
+            if (args.pressed && args.button == events::MouseButton::Left) {
+                ToggleHelpMenu();
+            }
+        });
+    startMenu->AddDisplayable(helpOption);
 
     auto connectOption = std::make_shared<UI::menu::ClickOption>(
         "connectOption", 1.0, "Connect to server");
@@ -220,6 +235,44 @@ void CreateConnectMenu(const std::shared_ptr<GameManager> &gameManager) {
     connectMenu->AddDisplayable(inputOption);
 }
 
+void CreateHelpMenu() {
+    auto helpMenu = std::make_shared<UI::menu::Menu>(
+        "Welcome to admirals conquest!", Color::BLACK,
+        Color::FromRGBA(20, 20, 20, 140), 100);
+    GameData::engine->AddLayer(GameData::HelpMenuIdx, helpMenu, false);
+
+    std::vector<std::string> sentences = {
+        "Win by destroying the enemy base.",
+        "Spend gold to buy ships.",
+        "Buy ships by clicking the ship icons.",
+        "Gold generates passively.",
+        "Islands give extra gold.",
+        "Select ships by clicking on them.",
+        "You can also drag to select multiple.",
+        "Click on the grid to move ships.",
+        "Click on enemy ships to attack them.",
+        "Click on the enemy base to attack it.",
+        ""};
+
+    float order = sentences.size() + 1;
+    for (const auto &sentence : sentences) {
+        auto text = std::make_shared<UI::menu::TextOption>(
+            "helpText" + std::to_string(order), order--, sentence);
+        helpMenu->AddDisplayable(text);
+    }
+
+    auto returnOption = std::make_shared<UI::menu::ClickOption>(
+        "returnOption", order--, "Return");
+    returnOption->onClick.Subscribe(
+        [](void *, events::MouseClickEventArgs &args) {
+            if (args.pressed && args.button == events::MouseButton::Left) {
+                ToggleHelpMenu();
+            }
+        });
+
+    helpMenu->AddDisplayable(returnOption);
+}
+
 int main(int, char *[]) {
     GameData::engine = std::make_unique<Engine>(
         "Admirals", GridWidth, GridHeight,
@@ -242,6 +295,7 @@ int main(int, char *[]) {
     CreateStartMenu(gameManager);
     CreateStartMenuScene(atlas);
     CreateConnectMenu(gameManager);
+    CreateHelpMenu();
 
     GameData::SceneStore = GameData::StartMenuScene;
     SwapEngineScene();


### PR DESCRIPTION
Added a help menu to the MVP with some game instructions, it looks like this:

![image](https://github.com/joelsiks/admirals/assets/61315185/75b4304c-1547-4333-8b26-d89d08ff3c84)

One issue with this is that the font is very large, so it's not possible to fit a lot of text on one line. As a result, the instructions are brief and done with very short sentences. I tried longer multi-line instructions but that looked even worse.

I am very open to changing the actual text to be more informative if you have any ideas.