### PR TITLE
Waiting for opponent menu fix

### DIFF
--- a/src/mvp/managers/MenuManager.cpp
+++ b/src/mvp/managers/MenuManager.cpp
@@ -90,6 +90,7 @@ void MenuManager::ShowServerDisconnectMenu() const {
     GameData::engine->ActivateLayer(ServerDisconnectMenuIdx);
     GameData::engine->DeactivateLayer(GameData::GameUIIdx);
     GameData::engine->DeactivateLayer(OpponentDisconnectMenuIdx);
+    GameData::engine->DeactivateLayer(WaitingMenuMenuIdx);
 }
 
 void MenuManager::ShowWaitingMenu() const {


### PR DESCRIPTION
Fixes menus where the server would close when waiting for an opponent, or if the server had already closed when pressing "play again"

Before, the "Waiting for opponent" menu would stay up, now it is closed before showing the "Game server closed" menu